### PR TITLE
Add support for Python 3.11-3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: 
-      - master
 defaults:
   run:
     shell: bash
@@ -15,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:  [ubuntu, macos]#,windows]
-        py:  ["3.9", "3.10", "3.11"]
+        py:  ["3.9", "3.10", "3.11", "3.12"]
         include:
           #- os: windows
           #  shell: "/usr/bin/bash"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ licenses = {
 }
 statuses = [ '1 - Planning', '2 - Pre-Alpha', '3 - Alpha',
     '4 - Beta', '5 - Production/Stable', '6 - Mature', '7 - Inactive' ]
-py_versions = '2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10'.split()
+py_versions = '2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12'.split()
 min_python = cfg['min_python']
 lic = licenses[cfg['license']]
 


### PR DESCRIPTION
Python 3.11 was released in October 2022 and 3.12 in October 2023:

https://devguide.python.org/versions/

We can't add 3.13 yet (October 2024) because PyTorch doesn't fully support it yet:

https://github.com/pytorch/pytorch/issues/130249
