### PR TITLE
Vendor `typing._allowed_types` removed in Python 3.14

### DIFF
--- a/fastcore/basics.py
+++ b/fastcore/basics.py
@@ -33,6 +33,10 @@ except ImportError: UnionType = None
 # %% ../nbs/01_basics.ipynb
 defaults = SimpleNamespace()
 
+_allowed_types = (types.FunctionType, types.BuiltinFunctionType,
+                  types.MethodType, types.ModuleType,
+                  WrapperDescriptorType, MethodWrapperType, MethodDescriptorType)
+
 # %% ../nbs/01_basics.ipynb
 def ifnone(a, b):
     "`b` if `a` is None else `a`"
@@ -352,7 +356,7 @@ def _eval_type(t, glb, loc):
 
 def type_hints(f):
     "Like `typing.get_type_hints` but returns `{}` if not allowed type"
-    if not isinstance(f, typing._allowed_types): return {}
+    if not isinstance(f, _allowed_types): return {}
     ann,glb,loc = get_annotations_ex(f)
     return {k:_eval_type(v,glb,loc) for k,v in ann.items()}
 

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -60,7 +60,11 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "defaults = SimpleNamespace()"
+    "defaults = SimpleNamespace()\n",
+    "\n",
+    "_allowed_types = (types.FunctionType, types.BuiltinFunctionType,\n",
+    "                  types.MethodType, types.ModuleType,\n",
+    "                  WrapperDescriptorType, MethodWrapperType, MethodDescriptorType)"
    ]
   },
   {
@@ -1870,7 +1874,7 @@
     "\n",
     "def type_hints(f):\n",
     "    \"Like `typing.get_type_hints` but returns `{}` if not allowed type\"\n",
-    "    if not isinstance(f, typing._allowed_types): return {}\n",
+    "    if not isinstance(f, _allowed_types): return {}\n",
     "    ann,glb,loc = get_annotations_ex(f)\n",
     "    return {k:_eval_type(v,glb,loc) for k,v in ann.items()}"
    ]


### PR DESCRIPTION
Fix for Python 3.14 alpha, which removed the private/internal (underscored) `typing._allowed_types`: https://github.com/python/cpython/pull/124090

Before:

```pytb
❯ python3.14 -m pip install ghapi -q
❯ python3.14 -c "from ghapi.all import GhApi; print(GhApi)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from ghapi.all import GhApi
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/ghapi/all.py", line 1, in <module>
    from .core import *
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/ghapi/core.py", line 9, in <module>
    from fastcore.all import *
  File "/private/tmp/fastcore/fastcore/all.py", line 3, in <module>
    from .dispatch import *
  File "/private/tmp/fastcore/fastcore/dispatch.py", line 174, in <module>
    @typedispatch
     ^^^^^^^^^^^^
  File "/private/tmp/fastcore/fastcore/dispatch.py", line 150, in __call__
    self.d[nm].add(f)
    ~~~~~~~~~~~~~~^^^
  File "/private/tmp/fastcore/fastcore/dispatch.py", line 93, in add
    else: a0,a1 = _p2_anno(f)
                  ~~~~~~~~^^^
  File "/private/tmp/fastcore/fastcore/dispatch.py", line 46, in _p2_anno
    hints = type_hints(f)
  File "/private/tmp/fastcore/fastcore/basics.py", line 355, in type_hints
    if not isinstance(f, typing._allowed_types): return {}
                         ^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/typing.py", line 3829, in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
AttributeError: module 'typing' has no attribute '_allowed_types'
```

After:

```console
❯ python3.14 -c "from ghapi.all import GhApi; print(GhApi)"
<class 'ghapi.core.GhApi'>
```

