### PR TITLE
remove unused var from parse_docstring

### DIFF
--- a/fastcore/docments.py
+++ b/fastcore/docments.py
@@ -33,7 +33,6 @@ def docstring(sym):
 # %% ../nbs/06_docments.ipynb
 def parse_docstring(sym):
     "Parse a numpy-style docstring in `sym`"
-    docs = docstring(sym)
     return AttrDict(**docscrape.NumpyDocString(docstring(sym)))
 
 # %% ../nbs/06_docments.ipynb

--- a/nbs/06_docments.ipynb
+++ b/nbs/06_docments.ipynb
@@ -168,7 +168,6 @@
     "#|export\n",
     "def parse_docstring(sym):\n",
     "    \"Parse a numpy-style docstring in `sym`\"\n",
-    "    docs = docstring(sym)\n",
     "    return AttrDict(**docscrape.NumpyDocString(docstring(sym)))"
    ]
   },


### PR DESCRIPTION
This PR cleans up unused line of code – `docs = docstring(sym)` 