### PR TITLE
Update Config to support ConfigParser keyword arguments

### DIFF
--- a/fastcore/foundation.py
+++ b/fastcore/foundation.py
@@ -260,11 +260,11 @@ def read_config_file(file, **kwargs):
 # %% ../nbs/02_foundation.ipynb
 class Config:
     "Reading and writing `ConfigParser` ini files"
-    def __init__(self, cfg_path, cfg_name, create=None, save=True, extra_files=None, types=None):
+    def __init__(self, cfg_path, cfg_name, create=None, save=True, extra_files=None, types=None, **cfg_kwargs):
         self.types = types or {}
         cfg_path = Path(cfg_path).expanduser().absolute()
         self.config_path,self.config_file = cfg_path,cfg_path/cfg_name
-        self._cfg = ConfigParser()
+        self._cfg = ConfigParser(**cfg_kwargs)
         self.d = self._cfg['DEFAULT']
         found = [Path(o) for o in self._cfg.read(L(extra_files)+[self.config_file], encoding='utf8')]
         if self.config_file not in found and create is not None:

--- a/nbs/02_foundation.ipynb
+++ b/nbs/02_foundation.ipynb
@@ -256,6 +256,14 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nathan/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
      "data": {
       "text/markdown": [
        "---\n",
@@ -1227,7 +1235,7 @@
        "\n",
        ">      L.groupby (key, val=<function noop>)\n",
        "\n",
-       "*Same as `groupby`*"
+       "*Same as `fastcore.basics.groupby`*"
       ],
       "text/plain": [
        "---\n",
@@ -1238,7 +1246,7 @@
        "\n",
        ">      L.groupby (key, val=<function noop>)\n",
        "\n",
-       "*Same as `groupby`*"
+       "*Same as `fastcore.basics.groupby`*"
       ]
      },
      "execution_count": null,
@@ -2301,11 +2309,11 @@
     "#|export\n",
     "class Config:\n",
     "    \"Reading and writing `ConfigParser` ini files\"\n",
-    "    def __init__(self, cfg_path, cfg_name, create=None, save=True, extra_files=None, types=None):\n",
+    "    def __init__(self, cfg_path, cfg_name, create=None, save=True, extra_files=None, types=None, **cfg_kwargs):\n",
     "        self.types = types or {}\n",
     "        cfg_path = Path(cfg_path).expanduser().absolute()\n",
     "        self.config_path,self.config_file = cfg_path,cfg_path/cfg_name\n",
-    "        self._cfg = ConfigParser()\n",
+    "        self._cfg = ConfigParser(**cfg_kwargs)\n",
     "        self.d = self._cfg['DEFAULT']\n",
     "        found = [Path(o) for o in self._cfg.read(L(extra_files)+[self.config_file], encoding='utf8')]\n",
     "        if self.config_file not in found and create is not None:\n",
@@ -2419,6 +2427,54 @@
     "cfg = Config('..', 'tmp.ini', create=_d, save=False)\n",
     "test_eq(cfg.user,'fastai')\n",
     "assert not Path('../tmp.ini').exists()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also pass in `ConfigParser` `kwargs` to change the behavior of how your configuration file will be parsed. For example, by default, inline comments are not handled by `Config`. However, if you pass in the `inline_comment_prefixes` with whatever your comment symbol is, you'll overwrite this behavior. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a complete example config file with comments\n",
+    "cfg_str = \"\"\"\\\n",
+    "[DEFAULT]\n",
+    "user = fastai # inline comment\n",
+    "\n",
+    "# Library configuration\n",
+    "lib_name = fastcore\n",
+    "\n",
+    "# Paths\n",
+    "some_path = test \n",
+    "\n",
+    "# Feature flags\n",
+    "some_bool = True\n",
+    "\n",
+    "# Numeric settings\n",
+    "some_num = # missing value\n",
+    "\"\"\"\n",
+    "\n",
+    "with open('../tmp.ini', 'w') as f:\n",
+    "    f.write(cfg_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now read it back to verify\n",
+    "try: cfg = Config('..', 'tmp.ini', inline_comment_prefixes=('#'))\n",
+    "finally: os.unlink('../tmp.ini')\n",
+    "test_eq(cfg.user,'fastai')\n",
+    "test_eq(cfg.some_num,'')"
    ]
   },
   {

--- a/nbs/02_foundation.ipynb
+++ b/nbs/02_foundation.ipynb
@@ -256,14 +256,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/nathan/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
-    {
      "data": {
       "text/markdown": [
        "---\n",


### PR DESCRIPTION
This PR adds a `cfg_kwargs` argument to the Config object in the foundations module. This allows a user to pass keyword arguments directly to the ConfigParser object, allowing for things like overriding the behavior on how inline comments are handled. An example showcasing this functionality is also added to the docs.