### PR TITLE
Fix colab link

### DIFF
--- a/nbs/000_tour.ipynb
+++ b/nbs/000_tour.ipynb
@@ -48,7 +48,7 @@
     {
      "data": {
       "text/markdown": [
-       "[Open `index` in Colab](https://colab.research.google.com/github/fastai/fastcore/blob/master/nbs/index.ipynb)"
+       "[Open `000_tour` in Colab](https://colab.research.google.com/github/AnswerDotAI/fastcore/blob/master/nbs/000_tour.ipynb)"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -59,7 +59,7 @@
     }
    ],
    "source": [
-    "colab_link('index')"
+    "colab_link('000_tour')"
    ]
   },
   {
@@ -77,7 +77,7 @@
     {
      "data": {
       "text/plain": [
-       "<function fastcore.foundation.coll_repr(c, max_n=10)>"
+       "<function fastcore.foundation.coll_repr(c, max_n=20)>"
       ]
      },
      "execution_count": null,
@@ -357,7 +357,7 @@
     {
      "data": {
       "text/plain": [
-       "__main__.ProductPage(author='Jeremy', price=1.5, cost=0.5)"
+       "ProductPage(author='Jeremy', price=1.5, cost=0.5)"
       ]
      },
      "execution_count": null,
@@ -467,7 +467,7 @@
     {
      "data": {
       "text/plain": [
-       "(#20) [5,1,9,10,18,13,6,17,3,16...]"
+       "(#20) [4,14,1,7,3,18,5,6,11,15,13,17,16,2,8,10,0,9,12,19]"
       ]
      },
      "execution_count": null,
@@ -495,7 +495,7 @@
     {
      "data": {
       "text/plain": [
-       "(#3) [9,18,6]"
+       "(#3) [1,3,5]"
       ]
      },
      "execution_count": null,
@@ -522,7 +522,7 @@
     {
      "data": {
       "text/plain": [
-       "(#5) [4,7,9,18,19]"
+       "(#5) [5,9,11,12,19]"
       ]
      },
      "execution_count": null,


### PR DESCRIPTION
Currently, the colab link, `colab_link('index')`, is set to index points to [index notebook](https://colab.research.google.com/github/fastai/fastcore/blob/master/nbs/index.ipynb), which is not the tour page. Therefore, the description, `if you want to follow along with this tour, click the link below:` is misleading.

This PR fixes this issue by changing to `"colab_link('000_tour')"`, which  generates  colab link to [tour notebook](https://colab.research.google.com/github/AnswerDotAI/fastcore/blob/master/nbs/000_tour.ipynb).