### PR TITLE
Add a setter to patch

### DIFF
--- a/fastcore/basics.py
+++ b/fastcore/basics.py
@@ -1046,12 +1046,7 @@ def patch_to(cls, as_prop=False, cls_method=False, set_prop=False):
             nf.__qualname__ = f"{c_.__name__}.{nm}"
             if cls_method: setattr(c_, nm, _clsmethod(nf))
             else:
-                if set_prop:
-                    if isinstance(getattr(c_, nm, None), property):
-                        prop = getattr(c_, nm)
-                        setattr(c_, nm, prop.setter(nf))
-                    else:
-                        raise AttributeError(f"Cannot set property setter: {nm} is not a property of {c_}")
+                if set_prop: setattr(c_, nm, getattr(c_, nm).setter(nf))
                 elif as_prop: setattr(c_, nm, property(nf))
                 else:
                     onm = '_orig_'+nm

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -4700,7 +4700,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L829){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L861){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### fastuple\n",
        "\n",
@@ -4711,7 +4711,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L829){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L861){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### fastuple\n",
        "\n",
@@ -4785,7 +4785,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L848){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L880){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "##### fastuple.add\n",
        "\n",
@@ -4796,7 +4796,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L848){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L880){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "##### fastuple.add\n",
        "\n",
@@ -4835,7 +4835,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L844){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L876){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "##### fastuple.mul\n",
        "\n",
@@ -4846,7 +4846,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L844){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L876){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "##### fastuple.mul\n",
        "\n",
@@ -4996,7 +4996,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L875){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L907){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### bind\n",
        "\n",
@@ -5007,7 +5007,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L875){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L907){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### bind\n",
        "\n",
@@ -5645,7 +5645,7 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def patch_to(cls, as_prop=False, cls_method=False):\n",
+    "def patch_to(cls, as_prop=False, cls_method=False, set_prop=False):\n",
     "    \"Decorator: add `f` to `cls`\"\n",
     "    if not isinstance(cls, (tuple,list)): cls=(cls,)\n",
     "    def _inner(f):\n",
@@ -5657,7 +5657,13 @@
     "            nf.__qualname__ = f\"{c_.__name__}.{nm}\"\n",
     "            if cls_method: setattr(c_, nm, _clsmethod(nf))\n",
     "            else:\n",
-    "                if as_prop: setattr(c_, nm, property(nf))\n",
+    "                if set_prop:\n",
+    "                    if isinstance(getattr(c_, nm, None), property):\n",
+    "                        prop = getattr(c_, nm)\n",
+    "                        setattr(c_, nm, prop.setter(nf))\n",
+    "                    else:\n",
+    "                        raise AttributeError(f\"Cannot set property setter: {nm} is not a property of {c_}\")\n",
+    "                elif as_prop: setattr(c_, nm, property(nf))\n",
     "                else:\n",
     "                    onm = '_orig_'+nm\n",
     "                    if hasattr(c_, nm) and not hasattr(c_, onm): setattr(c_, onm, getattr(c_, nm))\n",
@@ -5757,6 +5763,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Once you have a property, you can assign a setter with `set_prop=True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class _T2():\n",
+    "    def __init__(self, val): self._val = val\n",
+    "\n",
+    "@patch_to(_T2, as_prop=True)\n",
+    "def val(self): return self._val\n",
+    "\n",
+    "t = _T2(2)\n",
+    "test_eq(t.val, 2)\n",
+    "\n",
+    "@patch_to(_T2, set_prop=True)\n",
+    "def val(self, val): self._val = val\n",
+    "\n",
+    "t.val = 3\n",
+    "test_eq(t.val, 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Instead of passing one class to the `@patch_to` decorator, you can pass multiple classes in a tuple to simulteanously patch more than one class with the same method:"
    ]
   },
@@ -5785,12 +5820,12 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def patch(f=None, *, as_prop=False, cls_method=False):\n",
+    "def patch(f=None, *, as_prop=False, cls_method=False,  set_prop=False):\n",
     "    \"Decorator: add `f` to the first parameter's class (based on f's type annotations)\"\n",
-    "    if f is None: return partial(patch, as_prop=as_prop, cls_method=cls_method)\n",
+    "    if f is None: return partial(patch, as_prop=as_prop, cls_method=cls_method, set_prop=set_prop)\n",
     "    ann,glb,loc = get_annotations_ex(f)\n",
     "    cls = union2tuple(eval_type(ann.pop('cls') if cls_method else next(iter(ann.values())), glb, loc))\n",
-    "    return patch_to(cls, as_prop=as_prop, cls_method=cls_method)(f)"
+    "    return patch_to(cls, as_prop=as_prop, cls_method=cls_method, set_prop=set_prop)(f)"
    ]
   },
   {
@@ -5847,7 +5882,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Just like `patch_to` decorator you can use `as_prop` and `cls_method` parameters with `patch` decorator:"
+    "Just like `patch_to` decorator you can use `as_prop`, `set_prop`, and `cls_method` parameters with `patch` decorator:"
    ]
   },
   {
@@ -5861,6 +5896,28 @@
     "\n",
     "t = _T5(4)\n",
     "test_eq(t.add_ten, 14)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class _T2():\n",
+    "    def __init__(self, val): self._val = val\n",
+    "\n",
+    "@patch(as_prop=True)\n",
+    "def val(self:_T2): return self._val\n",
+    "\n",
+    "t = _T2(2)\n",
+    "test_eq(t.val, 2)\n",
+    "\n",
+    "@patch(set_prop=True)\n",
+    "def val(self:_T2, val): self._val = val\n",
+    "\n",
+    "t.val = 3\n",
+    "test_eq(t.val, 3)"
    ]
   },
   {
@@ -5972,11 +6029,11 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1047){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1079){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ImportEnum\n",
        "\n",
-       ">      ImportEnum (new_class_name, names, module=None, qualname=None, type=None,\n",
+       ">      ImportEnum (value, names=None, module=None, qualname=None, type=None,\n",
        ">                  start=1, boundary=None)\n",
        "\n",
        "*An `Enum` that can have its values imported*"
@@ -5984,11 +6041,11 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1047){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1079){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ImportEnum\n",
        "\n",
-       ">      ImportEnum (new_class_name, names, module=None, qualname=None, type=None,\n",
+       ">      ImportEnum (value, names=None, module=None, qualname=None, type=None,\n",
        ">                  start=1, boundary=None)\n",
        "\n",
        "*An `Enum` that can have its values imported*"
@@ -6037,11 +6094,11 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1055){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1087){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### StrEnum\n",
        "\n",
-       ">      StrEnum (new_class_name, names, module=None, qualname=None, type=None,\n",
+       ">      StrEnum (value, names=None, module=None, qualname=None, type=None,\n",
        ">               start=1, boundary=None)\n",
        "\n",
        "*An `ImportEnum` that behaves like a `str`*"
@@ -6049,11 +6106,11 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1055){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1087){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### StrEnum\n",
        "\n",
-       ">      StrEnum (new_class_name, names, module=None, qualname=None, type=None,\n",
+       ">      StrEnum (value, names=None, module=None, qualname=None, type=None,\n",
        ">               start=1, boundary=None)\n",
        "\n",
        "*An `ImportEnum` that behaves like a `str`*"
@@ -6102,11 +6159,11 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1065){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1097){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ValEnum\n",
        "\n",
-       ">      ValEnum (new_class_name, names, module=None, qualname=None, type=None,\n",
+       ">      ValEnum (value, names=None, module=None, qualname=None, type=None,\n",
        ">               start=1, boundary=None)\n",
        "\n",
        "*An `ImportEnum` that stringifies using values*"
@@ -6114,11 +6171,11 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1065){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1097){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ValEnum\n",
        "\n",
-       ">      ValEnum (new_class_name, names, module=None, qualname=None, type=None,\n",
+       ">      ValEnum (value, names=None, module=None, qualname=None, type=None,\n",
        ">               start=1, boundary=None)\n",
        "\n",
        "*An `ImportEnum` that stringifies using values*"
@@ -6191,7 +6248,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1070){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1102){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### Stateful\n",
        "\n",
@@ -6202,7 +6259,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1070){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1102){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### Stateful\n",
        "\n",
@@ -6353,7 +6410,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1107){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1139){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### PrettyString\n",
        "\n",
@@ -6364,7 +6421,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/basics.py#L1107){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1139){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### PrettyString\n",
        "\n",
@@ -6489,7 +6546,7 @@
     {
      "data": {
       "text/plain": [
-       "10"
+       "22"
       ]
      },
      "execution_count": null,

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -163,7 +163,7 @@
        "'SomeClass()'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -191,7 +191,7 @@
        "\"SomeClass(a=1, b='foo')\""
       ]
      },
-     "execution_count": 11,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -224,7 +224,7 @@
        "\"AnotherClass(c=SomeClass(a=1, b='foo'), d='bar')\""
       ]
      },
-     "execution_count": 12,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -256,7 +256,7 @@
        "\"SomeClass(a=1, b='foo')\""
       ]
      },
-     "execution_count": 13,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -299,7 +299,7 @@
        "\"SomeClass(a=1, b='foo')\""
       ]
      },
-     "execution_count": 15,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -334,7 +334,7 @@
        "(True, False)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -345,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +402,7 @@
        "        [6, 7, 8]])]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -414,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -423,7 +423,7 @@
        "[array([1, 2])]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -441,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -458,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -512,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -552,7 +552,7 @@
        " (None, False)]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -564,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -590,7 +590,7 @@
        "False"
       ]
      },
-     "execution_count": 31,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -601,7 +601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -613,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -622,7 +622,7 @@
        "False"
       ]
      },
-     "execution_count": 33,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -669,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -699,7 +699,7 @@
        "*Dynamically create a class, optionally inheriting from `sup`, containing `fld_names`*"
       ]
      },
-     "execution_count": 35,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -710,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -719,7 +719,7 @@
        "'_t(a=1, b=3)'"
       ]
      },
-     "execution_count": 36,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -749,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -798,7 +798,7 @@
        "{}"
       ]
      },
-     "execution_count": 39,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -817,7 +817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,7 +832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -859,7 +859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -887,7 +887,7 @@
        "*Context manager to ignore exceptions*"
       ]
      },
-     "execution_count": 43,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -898,7 +898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -909,7 +909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -923,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -932,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -951,7 +951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -970,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -981,7 +981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -992,7 +992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1018,7 +1018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1042,7 +1042,7 @@
        "*Do nothing*"
       ]
      },
-     "execution_count": 52,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1053,7 +1053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1063,7 +1063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1087,7 +1087,7 @@
        "*Do nothing (method)*"
       ]
      },
-     "execution_count": 54,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1098,7 +1098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1122,7 +1122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1141,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1153,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1174,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1200,7 +1200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1219,7 +1219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,7 +1233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1243,7 +1243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1253,7 +1253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1287,7 +1287,7 @@
        "(True, False, True, False, 1)"
       ]
      },
-     "execution_count": 65,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1305,7 +1305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1314,7 +1314,7 @@
        "(True, False, True, False, 1)"
       ]
      },
-     "execution_count": 66,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1325,7 +1325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1337,7 +1337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1347,7 +1347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1359,7 +1359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1371,7 +1371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1383,7 +1383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1397,7 +1397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1422,7 +1422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1445,7 +1445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1457,7 +1457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1481,7 +1481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1500,7 +1500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1513,7 +1513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1529,7 +1529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1555,7 +1555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1579,7 +1579,7 @@
        " 'f': {'c': 1, 'd': 2, 'e': 4, 'f': [1, 2, 3, 4, 5]}}"
       ]
      },
-     "execution_count": 81,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1592,7 +1592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1608,7 +1608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1620,7 +1620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1641,7 +1641,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1655,7 +1655,7 @@
        "          f={'c': 1, 'd': 2, 'e': 4, 'f': [1, 2, 3, 4, 5]})"
       ]
      },
-     "execution_count": 85,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1674,7 +1674,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1683,7 +1683,7 @@
        "1"
       ]
      },
-     "execution_count": 86,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1701,7 +1701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1710,7 +1710,7 @@
        "['a', 'b', 'c', 'd', 'e', 'f']"
       ]
      },
-     "execution_count": 87,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1721,7 +1721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1782,7 +1782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1805,7 +1805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1814,7 +1814,7 @@
        "__main__._T2a"
       ]
      },
-     "execution_count": 90,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1836,7 +1836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1845,7 +1845,7 @@
        "typing.Union[__main__._T2a, __main__._T2b]"
       ]
      },
-     "execution_count": 91,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1860,7 +1860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1885,7 +1885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1900,7 +1900,7 @@
        " method_descriptor]"
       ]
      },
-     "execution_count": 93,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1918,7 +1918,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1937,7 +1937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1948,7 +1948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1972,7 +1972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1983,7 +1983,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1995,7 +1995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2015,7 +2015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2034,7 +2034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2046,7 +2046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2072,7 +2072,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2085,7 +2085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2098,7 +2098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2111,7 +2111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2120,7 +2120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2145,7 +2145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2165,7 +2165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2180,7 +2180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2212,7 +2212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2229,7 +2229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2246,7 +2246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2256,7 +2256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2273,7 +2273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2289,7 +2289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2302,7 +2302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2325,7 +2325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2345,7 +2345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2367,7 +2367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2380,7 +2380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2395,7 +2395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2411,7 +2411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2433,7 +2433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2448,7 +2448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2473,7 +2473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2494,7 +2494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2514,7 +2514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2529,7 +2529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2541,7 +2541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2554,7 +2554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2566,7 +2566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2581,7 +2581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2593,7 +2593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2605,7 +2605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2614,7 +2614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2627,7 +2627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2637,7 +2637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2649,7 +2649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2658,7 +2658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2670,7 +2670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2692,7 +2692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2704,7 +2704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2719,7 +2719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2731,7 +2731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2740,7 +2740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2749,7 +2749,7 @@
        "[1, 2]"
       ]
      },
-     "execution_count": 146,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2760,7 +2760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2772,7 +2772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2782,7 +2782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2795,7 +2795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2808,7 +2808,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2821,7 +2821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2836,7 +2836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2853,7 +2853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2869,7 +2869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2894,7 +2894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2922,7 +2922,7 @@
        "*Inherit from this to have all attr accesses in `self._xtra` passed down to `self.default`*"
       ]
      },
-     "execution_count": 156,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2956,7 +2956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2980,7 +2980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2999,7 +2999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3015,7 +3015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3042,7 +3042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3067,7 +3067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3095,7 +3095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3116,7 +3116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3139,7 +3139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3165,7 +3165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3193,7 +3193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3216,7 +3216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3226,7 +3226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3261,7 +3261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3283,7 +3283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3296,7 +3296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3319,7 +3319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3354,7 +3354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3371,7 +3371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3382,7 +3382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3396,7 +3396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3408,7 +3408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3419,7 +3419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3434,7 +3434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3446,7 +3446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3455,7 +3455,7 @@
        "[0, 1, 2, 3, 4, 5]"
       ]
      },
-     "execution_count": 181,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3466,7 +3466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3475,7 +3475,7 @@
        "['abc', 'xyz', 'foo', 'bar']"
       ]
      },
-     "execution_count": 182,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3486,7 +3486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3498,7 +3498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3508,7 +3508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3520,7 +3520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3532,7 +3532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3544,7 +3544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3555,7 +3555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3567,7 +3567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3581,7 +3581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3593,7 +3593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3604,7 +3604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3616,7 +3616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 194,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3625,7 +3625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3647,7 +3647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3663,7 +3663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3679,7 +3679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3695,7 +3695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3704,7 +3704,7 @@
        "{1: [0], 3: [0, 2], 7: [0], 5: [3, 7], 8: [4], 4: [5]}"
       ]
      },
-     "execution_count": 199,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3716,7 +3716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3729,7 +3729,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3739,7 +3739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3751,7 +3751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3760,7 +3760,7 @@
        "{65: 'A', 66: 'B', 67: 'C', 68: 'D', 69: 'E', 70: 'F', 71: 'G', 72: 'H'}"
       ]
      },
-     "execution_count": 203,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3772,7 +3772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 204,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3781,7 +3781,7 @@
        "{65: 'A', 66: 'B', 70: 'F', 71: 'G'}"
       ]
      },
-     "execution_count": 204,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3792,7 +3792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 205,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3804,7 +3804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 206,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3813,7 +3813,7 @@
        "{65: 'A', 66: 'B'}"
       ]
      },
-     "execution_count": 206,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3824,7 +3824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 207,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3836,7 +3836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 208,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3845,7 +3845,7 @@
        "{70: 'F', 71: 'G'}"
       ]
      },
-     "execution_count": 208,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3856,7 +3856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 209,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3869,7 +3869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 210,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3881,7 +3881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 211,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3893,7 +3893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 212,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3902,7 +3902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 213,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3928,7 +3928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 214,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3947,7 +3947,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3964,7 +3964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 216,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3980,7 +3980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 217,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3996,7 +3996,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 218,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4013,7 +4013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 219,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4022,7 +4022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 220,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4035,7 +4035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 221,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4047,7 +4047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4061,7 +4061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4078,7 +4078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 224,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4091,7 +4091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4101,7 +4101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4113,7 +4113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 227,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4122,7 +4122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4136,7 +4136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 229,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4147,7 +4147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4162,7 +4162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4173,7 +4173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4190,7 +4190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4202,7 +4202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4220,7 +4220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 235,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4248,7 +4248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4259,7 +4259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4271,7 +4271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4288,7 +4288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 239,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4302,7 +4302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 240,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4314,7 +4314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4326,7 +4326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4338,7 +4338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 243,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4349,7 +4349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4374,7 +4374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4389,7 +4389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 246,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4405,7 +4405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 247,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4421,7 +4421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4434,7 +4434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4444,7 +4444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 250,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4456,7 +4456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 251,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4465,7 +4465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 252,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4480,7 +4480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 253,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4498,7 +4498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 254,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4519,7 +4519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 255,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4528,7 +4528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 256,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4540,7 +4540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 257,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4549,7 +4549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 258,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4561,7 +4561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 259,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4570,7 +4570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 260,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4582,7 +4582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 261,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4592,7 +4592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 262,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4604,7 +4604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 263,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4627,7 +4627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 264,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4648,7 +4648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 265,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4692,7 +4692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 266,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4720,7 +4720,7 @@
        "*A `tuple` with elementwise ops and more friendly __init__ behavior*"
       ]
      },
-     "execution_count": 266,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4759,7 +4759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 267,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4777,7 +4777,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 268,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4805,7 +4805,7 @@
        "*`+` is already defined in `tuple` for concat, so use `add` instead*"
       ]
      },
-     "execution_count": 268,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4816,7 +4816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 269,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4827,7 +4827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 270,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -4855,7 +4855,7 @@
        "*`*` is already defined in `tuple` for replicating, so use `mul` instead*"
       ]
      },
-     "execution_count": 270,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4866,7 +4866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 271,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4893,7 +4893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 272,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4912,7 +4912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 273,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4924,7 +4924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 274,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4950,7 +4950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 275,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4966,7 +4966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 276,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4988,7 +4988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 277,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5016,7 +5016,7 @@
        "*Same as `partial`, except you can use `arg0` `arg1` etc param placeholders*"
       ]
      },
-     "execution_count": 277,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5036,7 +5036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 278,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5056,7 +5056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 279,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5077,7 +5077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 280,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5093,7 +5093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 281,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5109,7 +5109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 282,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5118,7 +5118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 283,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5130,7 +5130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 284,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5140,7 +5140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 285,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5157,7 +5157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 286,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5173,7 +5173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 287,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5189,7 +5189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 288,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5205,7 +5205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 289,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5215,7 +5215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 290,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5234,7 +5234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 291,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5250,7 +5250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 292,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5264,7 +5264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 293,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5275,7 +5275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 294,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5291,7 +5291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 295,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5311,7 +5311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 296,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5327,7 +5327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 297,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5338,7 +5338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 298,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5350,7 +5350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 299,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5360,7 +5360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 300,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5370,7 +5370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 301,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5382,7 +5382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 302,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5407,7 +5407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 303,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5446,7 +5446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 304,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5461,7 +5461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 305,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5480,7 +5480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 306,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5521,7 +5521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 307,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5530,7 +5530,7 @@
        "[5, 2]"
       ]
      },
-     "execution_count": 307,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5551,7 +5551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 308,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5576,7 +5576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 309,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5585,7 +5585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 310,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5608,7 +5608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 311,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5618,7 +5618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 312,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5628,7 +5628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 313,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5640,7 +5640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 314,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5677,7 +5677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 315,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5699,7 +5699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 316,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5722,7 +5722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 317,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5743,7 +5743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 318,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5763,7 +5763,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 319,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5792,7 +5792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 320,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5810,7 +5810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 321,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5832,7 +5832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 322,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5855,7 +5855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 323,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5882,7 +5882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 324,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5895,7 +5895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 325,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5917,7 +5917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 326,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5931,7 +5931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 327,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5952,7 +5952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 328,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5979,7 +5979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 329,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5991,7 +5991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 330,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6001,7 +6001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 331,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6016,7 +6016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 332,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6046,7 +6046,7 @@
        "*An `Enum` that can have its values imported*"
       ]
      },
-     "execution_count": 332,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6057,7 +6057,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 333,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6069,7 +6069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 334,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6081,7 +6081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 335,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6111,7 +6111,7 @@
        "*An `ImportEnum` that behaves like a `str`*"
       ]
      },
-     "execution_count": 335,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6122,7 +6122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 336,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6134,7 +6134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 337,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6146,7 +6146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 338,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6176,7 +6176,7 @@
        "*An `ImportEnum` that stringifies using values*"
       ]
      },
-     "execution_count": 338,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6187,7 +6187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 339,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6208,7 +6208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 340,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6235,7 +6235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 341,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6263,7 +6263,7 @@
        "*A base class/mixin for objects that should not serialize all their state*"
       ]
      },
-     "execution_count": 341,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6274,7 +6274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 342,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6301,7 +6301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 343,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6324,7 +6324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 344,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6348,7 +6348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 345,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6372,7 +6372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 346,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6385,7 +6385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 347,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6397,7 +6397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 348,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6425,7 +6425,7 @@
        "*Little hack to get strings to show properly in Jupyter.*"
       ]
      },
-     "execution_count": 348,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6443,7 +6443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 349,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6452,7 +6452,7 @@
        "'a string\\nwith\\nnew\\nlines and\\ttabs'"
       ]
      },
-     "execution_count": 349,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6471,7 +6471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 350,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6483,7 +6483,7 @@
        "lines and\ttabs"
       ]
      },
-     "execution_count": 350,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6494,7 +6494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 351,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6509,7 +6509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 352,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6520,7 +6520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 353,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6535,7 +6535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 354,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -6544,7 +6544,7 @@
        "22"
       ]
      },
-     "execution_count": 354,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6555,7 +6555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 355,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6568,7 +6568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 356,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6581,7 +6581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 357,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6601,7 +6601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 358,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6611,7 +6611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 359,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6635,7 +6635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 360,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6647,7 +6647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 361,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6663,7 +6663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 362,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6682,7 +6682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 363,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6696,7 +6696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 364,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6712,7 +6712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 365,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6727,7 +6727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 366,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6740,7 +6740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 367,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6752,7 +6752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 368,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6770,7 +6770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 369,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6788,7 +6788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 370,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6839,7 +6839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 371,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6859,7 +6859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 372,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6881,7 +6881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 373,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6907,7 +6907,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 374,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6920,7 +6920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 375,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6953,7 +6953,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 376,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6976,7 +6976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 377,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6989,7 +6989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 378,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7006,7 +7006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 379,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7021,7 +7021,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 380,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7031,7 +7031,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 381,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7051,7 +7051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 382,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -7075,7 +7075,7 @@
        "*Same as `get_ipython` but returns `False` if not in IPython*"
       ]
      },
-     "execution_count": 382,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7086,7 +7086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 383,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -7110,7 +7110,7 @@
        "*Check if code is running in some kind of IPython environment*"
       ]
      },
-     "execution_count": 383,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7121,7 +7121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 384,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -7145,7 +7145,7 @@
        "*Check if the code is running in Google Colaboratory*"
       ]
      },
-     "execution_count": 384,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7156,7 +7156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 385,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -7180,7 +7180,7 @@
        "*Check if the code is running in a jupyter notebook*"
       ]
      },
-     "execution_count": 385,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7191,7 +7191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 386,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -7215,7 +7215,7 @@
        "*Check if the code is running in a jupyter notebook*"
       ]
      },
-     "execution_count": 386,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7233,7 +7233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 387,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -7242,7 +7242,7 @@
        "(True, True, False, True)"
       ]
      },
-     "execution_count": 387,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7260,7 +7260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 388,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7281,21 +7281,9 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -163,7 +163,7 @@
        "'SomeClass()'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -191,7 +191,7 @@
        "\"SomeClass(a=1, b='foo')\""
       ]
      },
-     "execution_count": null,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -224,7 +224,7 @@
        "\"AnotherClass(c=SomeClass(a=1, b='foo'), d='bar')\""
       ]
      },
-     "execution_count": null,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -256,7 +256,7 @@
        "\"SomeClass(a=1, b='foo')\""
       ]
      },
-     "execution_count": null,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -299,7 +299,7 @@
        "\"SomeClass(a=1, b='foo')\""
       ]
      },
-     "execution_count": null,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -334,7 +334,7 @@
        "(True, False)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -345,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +402,7 @@
        "        [6, 7, 8]])]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -414,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -423,7 +423,7 @@
        "[array([1, 2])]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -441,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -458,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -512,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -552,7 +552,7 @@
        " (None, False)]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -564,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -590,7 +590,7 @@
        "False"
       ]
      },
-     "execution_count": null,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -601,7 +601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -613,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -622,7 +622,7 @@
        "False"
       ]
      },
-     "execution_count": null,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,7 +633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -669,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -699,7 +699,7 @@
        "*Dynamically create a class, optionally inheriting from `sup`, containing `fld_names`*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -710,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -719,7 +719,7 @@
        "'_t(a=1, b=3)'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -749,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -798,7 +798,7 @@
        "{}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -817,7 +817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,7 +832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -859,7 +859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -887,7 +887,7 @@
        "*Context manager to ignore exceptions*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -898,7 +898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -909,7 +909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -923,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -932,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -951,7 +951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -970,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -981,7 +981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -992,7 +992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1018,7 +1018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -1042,7 +1042,7 @@
        "*Do nothing*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1053,7 +1053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1063,7 +1063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -1087,7 +1087,7 @@
        "*Do nothing (method)*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1098,7 +1098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1122,7 +1122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1141,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1153,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1174,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1200,7 +1200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1219,7 +1219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,7 +1233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1243,7 +1243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1253,7 +1253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
@@ -1287,7 +1287,7 @@
        "(True, False, True, False, 1)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1305,7 +1305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
@@ -1314,7 +1314,7 @@
        "(True, False, True, False, 1)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1325,7 +1325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1337,7 +1337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1347,7 +1347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1359,7 +1359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1371,7 +1371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1383,7 +1383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1397,7 +1397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1422,7 +1422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1445,7 +1445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1457,7 +1457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1481,7 +1481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1500,7 +1500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1513,7 +1513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1529,7 +1529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1555,7 +1555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -1579,7 +1579,7 @@
        " 'f': {'c': 1, 'd': 2, 'e': 4, 'f': [1, 2, 3, 4, 5]}}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1592,7 +1592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1608,7 +1608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1620,7 +1620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1641,7 +1641,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -1655,7 +1655,7 @@
        "          f={'c': 1, 'd': 2, 'e': 4, 'f': [1, 2, 3, 4, 5]})"
       ]
      },
-     "execution_count": null,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1674,7 +1674,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
@@ -1683,7 +1683,7 @@
        "1"
       ]
      },
-     "execution_count": null,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1701,7 +1701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -1710,7 +1710,7 @@
        "['a', 'b', 'c', 'd', 'e', 'f']"
       ]
      },
-     "execution_count": null,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1721,7 +1721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1782,7 +1782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1805,7 +1805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -1814,7 +1814,7 @@
        "__main__._T2a"
       ]
      },
-     "execution_count": null,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1836,7 +1836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
@@ -1845,7 +1845,7 @@
        "typing.Union[__main__._T2a, __main__._T2b]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1860,7 +1860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1885,7 +1885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
@@ -1900,7 +1900,7 @@
        " method_descriptor]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1918,7 +1918,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1937,7 +1937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1948,7 +1948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1972,7 +1972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1983,7 +1983,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1995,7 +1995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2015,7 +2015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2034,7 +2034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2046,7 +2046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2072,7 +2072,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2085,7 +2085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2098,7 +2098,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2111,7 +2111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2120,7 +2120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2145,7 +2145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2165,7 +2165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2180,7 +2180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2212,7 +2212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2229,7 +2229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2246,7 +2246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2256,7 +2256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2273,7 +2273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2289,7 +2289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2302,7 +2302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2325,7 +2325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2345,7 +2345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2367,7 +2367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2380,7 +2380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2395,7 +2395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2411,7 +2411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2433,7 +2433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2448,7 +2448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2473,7 +2473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2494,7 +2494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2514,7 +2514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2529,7 +2529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2541,7 +2541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2554,7 +2554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2566,7 +2566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2581,7 +2581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2593,7 +2593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2605,7 +2605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 135,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2614,7 +2614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2627,7 +2627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2637,7 +2637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2649,7 +2649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2658,7 +2658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2670,7 +2670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2692,7 +2692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2704,7 +2704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 143,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2719,7 +2719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2731,7 +2731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2740,7 +2740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 146,
    "metadata": {},
    "outputs": [
     {
@@ -2749,7 +2749,7 @@
        "[1, 2]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 146,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2760,7 +2760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2772,7 +2772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 148,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2782,7 +2782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2795,7 +2795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 150,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2808,7 +2808,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 151,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2821,7 +2821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 152,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2836,7 +2836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 153,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2853,7 +2853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 154,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2869,7 +2869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 155,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2894,7 +2894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 156,
    "metadata": {},
    "outputs": [
     {
@@ -2922,7 +2922,7 @@
        "*Inherit from this to have all attr accesses in `self._xtra` passed down to `self.default`*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 156,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2956,7 +2956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 157,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2980,7 +2980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 158,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2999,7 +2999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 159,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3015,7 +3015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 160,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3042,7 +3042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3067,7 +3067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 162,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3095,7 +3095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 163,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3116,7 +3116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 164,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3139,7 +3139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3165,7 +3165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3193,7 +3193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 167,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3216,7 +3216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 168,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3226,7 +3226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 169,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3261,7 +3261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3283,7 +3283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 171,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3296,7 +3296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 172,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3319,7 +3319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 173,
    "metadata": {},
    "outputs": [
     {
@@ -3354,7 +3354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 174,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3371,7 +3371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 175,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3382,7 +3382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 176,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3396,7 +3396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 177,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3408,7 +3408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 178,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3419,7 +3419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3434,7 +3434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3446,7 +3446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 181,
    "metadata": {},
    "outputs": [
     {
@@ -3455,7 +3455,7 @@
        "[0, 1, 2, 3, 4, 5]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 181,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3466,7 +3466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 182,
    "metadata": {},
    "outputs": [
     {
@@ -3475,7 +3475,7 @@
        "['abc', 'xyz', 'foo', 'bar']"
       ]
      },
-     "execution_count": null,
+     "execution_count": 182,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3486,7 +3486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 183,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3498,7 +3498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 184,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3508,7 +3508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 185,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3520,7 +3520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3532,7 +3532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 187,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3544,7 +3544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 188,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3555,7 +3555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3567,7 +3567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 190,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3581,7 +3581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 191,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3593,7 +3593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 192,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3604,7 +3604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 193,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3616,7 +3616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 194,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3625,7 +3625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 195,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3647,7 +3647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 196,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3663,7 +3663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 197,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3679,7 +3679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 198,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3695,7 +3695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 199,
    "metadata": {},
    "outputs": [
     {
@@ -3704,7 +3704,7 @@
        "{1: [0], 3: [0, 2], 7: [0], 5: [3, 7], 8: [4], 4: [5]}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 199,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3716,7 +3716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 200,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3729,7 +3729,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 201,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3739,7 +3739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 202,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3751,7 +3751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 203,
    "metadata": {},
    "outputs": [
     {
@@ -3760,7 +3760,7 @@
        "{65: 'A', 66: 'B', 67: 'C', 68: 'D', 69: 'E', 70: 'F', 71: 'G', 72: 'H'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 203,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3772,7 +3772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 204,
    "metadata": {},
    "outputs": [
     {
@@ -3781,7 +3781,7 @@
        "{65: 'A', 66: 'B', 70: 'F', 71: 'G'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 204,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3792,7 +3792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 205,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3804,7 +3804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 206,
    "metadata": {},
    "outputs": [
     {
@@ -3813,7 +3813,7 @@
        "{65: 'A', 66: 'B'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 206,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3824,7 +3824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 207,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3836,7 +3836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 208,
    "metadata": {},
    "outputs": [
     {
@@ -3845,7 +3845,7 @@
        "{70: 'F', 71: 'G'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 208,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3856,7 +3856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 209,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3869,7 +3869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 210,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3881,7 +3881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 211,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3893,7 +3893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 212,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3902,7 +3902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 213,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3928,7 +3928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 214,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3947,7 +3947,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 215,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3964,7 +3964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 216,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3980,7 +3980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 217,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3996,7 +3996,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 218,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4013,7 +4013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 219,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4022,7 +4022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 220,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4035,7 +4035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 221,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4047,7 +4047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 222,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4061,7 +4061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 223,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4078,7 +4078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 224,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4091,7 +4091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 225,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4101,7 +4101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 226,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4113,7 +4113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 227,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4122,7 +4122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 228,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4136,7 +4136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 229,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4147,7 +4147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 230,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4162,7 +4162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 231,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4173,7 +4173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 232,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4190,7 +4190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 233,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4202,7 +4202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 234,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4220,7 +4220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 235,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4248,7 +4248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 236,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4259,7 +4259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 237,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4271,7 +4271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 238,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4288,7 +4288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 239,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4302,7 +4302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 240,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4314,7 +4314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 241,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4326,7 +4326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 242,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4338,7 +4338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 243,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4349,7 +4349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 244,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4374,7 +4374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 245,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4389,7 +4389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 246,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4405,7 +4405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 247,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4421,7 +4421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 248,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4434,7 +4434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 249,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4444,7 +4444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 250,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4456,7 +4456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 251,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4465,7 +4465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 252,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4480,7 +4480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 253,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4498,7 +4498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 254,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4519,7 +4519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 255,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4528,7 +4528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 256,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4540,7 +4540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 257,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4549,7 +4549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 258,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4561,7 +4561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 259,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4570,7 +4570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 260,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4582,7 +4582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 261,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4592,7 +4592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 262,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4604,7 +4604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 263,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4627,7 +4627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 264,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4648,7 +4648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 265,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4692,7 +4692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 266,
    "metadata": {},
    "outputs": [
     {
@@ -4720,7 +4720,7 @@
        "*A `tuple` with elementwise ops and more friendly __init__ behavior*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 266,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4759,7 +4759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 267,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4777,7 +4777,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 268,
    "metadata": {},
    "outputs": [
     {
@@ -4805,7 +4805,7 @@
        "*`+` is already defined in `tuple` for concat, so use `add` instead*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 268,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4816,7 +4816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 269,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4827,7 +4827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 270,
    "metadata": {},
    "outputs": [
     {
@@ -4855,7 +4855,7 @@
        "*`*` is already defined in `tuple` for replicating, so use `mul` instead*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 270,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4866,7 +4866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 271,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4893,7 +4893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 272,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4912,7 +4912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 273,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4924,7 +4924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 274,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4950,7 +4950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 275,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4966,7 +4966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 276,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4988,7 +4988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 277,
    "metadata": {},
    "outputs": [
     {
@@ -5016,7 +5016,7 @@
        "*Same as `partial`, except you can use `arg0` `arg1` etc param placeholders*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 277,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5036,7 +5036,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 278,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5056,7 +5056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 279,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5077,7 +5077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 280,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5093,7 +5093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 281,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5109,7 +5109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 282,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5118,7 +5118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 283,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5130,7 +5130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 284,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5140,7 +5140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 285,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5157,7 +5157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 286,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5173,7 +5173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 287,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5189,7 +5189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 288,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5205,7 +5205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 289,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5215,7 +5215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 290,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5234,7 +5234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 291,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5250,7 +5250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 292,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5264,7 +5264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 293,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5275,7 +5275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 294,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5291,7 +5291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 295,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5311,7 +5311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 296,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5327,7 +5327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 297,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5338,7 +5338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 298,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5350,7 +5350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 299,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5360,7 +5360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 300,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5370,7 +5370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 301,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5382,7 +5382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 302,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5407,7 +5407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 303,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5446,7 +5446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 304,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5461,7 +5461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 305,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5480,7 +5480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 306,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5521,7 +5521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 307,
    "metadata": {},
    "outputs": [
     {
@@ -5530,7 +5530,7 @@
        "[5, 2]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 307,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5551,7 +5551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 308,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5576,7 +5576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 309,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5585,7 +5585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 310,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5608,7 +5608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 311,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5618,7 +5618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 312,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5628,7 +5628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 313,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5640,7 +5640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 314,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5657,12 +5657,7 @@
     "            nf.__qualname__ = f\"{c_.__name__}.{nm}\"\n",
     "            if cls_method: setattr(c_, nm, _clsmethod(nf))\n",
     "            else:\n",
-    "                if set_prop:\n",
-    "                    if isinstance(getattr(c_, nm, None), property):\n",
-    "                        prop = getattr(c_, nm)\n",
-    "                        setattr(c_, nm, prop.setter(nf))\n",
-    "                    else:\n",
-    "                        raise AttributeError(f\"Cannot set property setter: {nm} is not a property of {c_}\")\n",
+    "                if set_prop: setattr(c_, nm, getattr(c_, nm).setter(nf))\n",
     "                elif as_prop: setattr(c_, nm, property(nf))\n",
     "                else:\n",
     "                    onm = '_orig_'+nm\n",
@@ -5682,7 +5677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 315,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5704,7 +5699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 316,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5727,7 +5722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 317,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5748,7 +5743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 318,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5768,7 +5763,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 319,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5797,7 +5792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 320,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5815,7 +5810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 321,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5837,7 +5832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 322,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5860,7 +5855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 323,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5887,7 +5882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 324,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5900,7 +5895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 325,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5922,7 +5917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 326,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5936,7 +5931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 327,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5957,7 +5952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 328,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5984,7 +5979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 329,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5996,7 +5991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 330,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6006,7 +6001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 331,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6021,7 +6016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 332,
    "metadata": {},
    "outputs": [
     {
@@ -6029,7 +6024,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1079){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1080){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ImportEnum\n",
        "\n",
@@ -6041,7 +6036,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1079){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1080){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ImportEnum\n",
        "\n",
@@ -6051,7 +6046,7 @@
        "*An `Enum` that can have its values imported*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 332,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6062,7 +6057,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 333,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6074,7 +6069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 334,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6086,7 +6081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 335,
    "metadata": {},
    "outputs": [
     {
@@ -6094,7 +6089,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1087){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1088){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### StrEnum\n",
        "\n",
@@ -6106,7 +6101,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1087){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1088){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### StrEnum\n",
        "\n",
@@ -6116,7 +6111,7 @@
        "*An `ImportEnum` that behaves like a `str`*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 335,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6127,7 +6122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 336,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6139,7 +6134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 337,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6151,7 +6146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 338,
    "metadata": {},
    "outputs": [
     {
@@ -6159,7 +6154,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1097){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1098){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ValEnum\n",
        "\n",
@@ -6171,7 +6166,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1097){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1098){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ValEnum\n",
        "\n",
@@ -6181,7 +6176,7 @@
        "*An `ImportEnum` that stringifies using values*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 338,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6192,7 +6187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 339,
    "metadata": {},
    "outputs": [
     {
@@ -6213,7 +6208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 340,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6240,7 +6235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 341,
    "metadata": {},
    "outputs": [
     {
@@ -6248,7 +6243,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1102){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1103){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### Stateful\n",
        "\n",
@@ -6259,7 +6254,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1102){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1103){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### Stateful\n",
        "\n",
@@ -6268,7 +6263,7 @@
        "*A base class/mixin for objects that should not serialize all their state*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 341,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6279,7 +6274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 342,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6306,7 +6301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 343,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6329,7 +6324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 344,
    "metadata": {},
    "outputs": [
     {
@@ -6353,7 +6348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 345,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6377,7 +6372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 346,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6390,7 +6385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 347,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6402,7 +6397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 348,
    "metadata": {},
    "outputs": [
     {
@@ -6410,7 +6405,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1139){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1140){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### PrettyString\n",
        "\n",
@@ -6421,7 +6416,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1139){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1140){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### PrettyString\n",
        "\n",
@@ -6430,7 +6425,7 @@
        "*Little hack to get strings to show properly in Jupyter.*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 348,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6448,7 +6443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 349,
    "metadata": {},
    "outputs": [
     {
@@ -6457,7 +6452,7 @@
        "'a string\\nwith\\nnew\\nlines and\\ttabs'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 349,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6476,7 +6471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 350,
    "metadata": {},
    "outputs": [
     {
@@ -6488,7 +6483,7 @@
        "lines and\ttabs"
       ]
      },
-     "execution_count": null,
+     "execution_count": 350,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6499,7 +6494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 351,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6514,7 +6509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 352,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6525,7 +6520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 353,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6540,7 +6535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 354,
    "metadata": {},
    "outputs": [
     {
@@ -6549,7 +6544,7 @@
        "22"
       ]
      },
-     "execution_count": null,
+     "execution_count": 354,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6560,7 +6555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 355,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6573,7 +6568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 356,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6586,7 +6581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 357,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6606,7 +6601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 358,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6616,7 +6611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 359,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6640,7 +6635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 360,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6652,7 +6647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 361,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6668,7 +6663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 362,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6687,7 +6682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 363,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6701,7 +6696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 364,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6717,7 +6712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 365,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6732,7 +6727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 366,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6745,7 +6740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 367,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6757,7 +6752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 368,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6775,7 +6770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 369,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6793,7 +6788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 370,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6844,7 +6839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 371,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6864,7 +6859,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 372,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6886,7 +6881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 373,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6912,7 +6907,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 374,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6925,7 +6920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 375,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6958,7 +6953,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 376,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6981,7 +6976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 377,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6994,7 +6989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 378,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7011,7 +7006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 379,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7026,7 +7021,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 380,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7036,7 +7031,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 381,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7056,7 +7051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 382,
    "metadata": {},
    "outputs": [
     {
@@ -7080,7 +7075,7 @@
        "*Same as `get_ipython` but returns `False` if not in IPython*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 382,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7091,7 +7086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 383,
    "metadata": {},
    "outputs": [
     {
@@ -7115,7 +7110,7 @@
        "*Check if code is running in some kind of IPython environment*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 383,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7126,7 +7121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 384,
    "metadata": {},
    "outputs": [
     {
@@ -7150,7 +7145,7 @@
        "*Check if the code is running in Google Colaboratory*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 384,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7161,7 +7156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 385,
    "metadata": {},
    "outputs": [
     {
@@ -7185,7 +7180,7 @@
        "*Check if the code is running in a jupyter notebook*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 385,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7196,7 +7191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 386,
    "metadata": {},
    "outputs": [
     {
@@ -7220,7 +7215,7 @@
        "*Check if the code is running in a jupyter notebook*"
       ]
      },
-     "execution_count": null,
+     "execution_count": 386,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7238,7 +7233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 387,
    "metadata": {},
    "outputs": [
     {
@@ -7247,7 +7242,7 @@
        "(True, True, False, True)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 387,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7265,7 +7260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 388,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7286,9 +7281,21 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds a setter to `patch_to` and `patch` with `set_prop=True`.

Here are the changes:
- Creating a `setter` is limited to classes that already have a property with the same name. 
- It raises an `AttributeError` if there is no property with the name. 

