### PR TITLE
Add `headers` arg to `urljson`

### DIFF
--- a/fastcore/net.py
+++ b/fastcore/net.py
@@ -127,9 +127,9 @@ def urlread(url, data=None, headers=None, decode=True, return_json=False, return
     return (res,dict(hdrs)) if return_headers else res
 
 # %% ../nbs/03b_net.ipynb
-def urljson(url, data=None, timeout=None):
+def urljson(url, data=None, timeout=None, headers=None):
     "Retrieve `url` and decode json"
-    res = urlread(url, data=data, timeout=timeout)
+    res = urlread(url, data=data, timeout=timeout, headers=headers)
     return json.loads(res) if res else {}
 
 # %% ../nbs/03b_net.ipynb

--- a/fastcore/net.py
+++ b/fastcore/net.py
@@ -127,9 +127,9 @@ def urlread(url, data=None, headers=None, decode=True, return_json=False, return
     return (res,dict(hdrs)) if return_headers else res
 
 # %% ../nbs/03b_net.ipynb
-def urljson(url, data=None, timeout=None, headers=None):
+def urljson(url, data=None, headers=None, timeout=None):
     "Retrieve `url` and decode json"
-    res = urlread(url, data=data, timeout=timeout, headers=headers)
+    res = urlread(url, data=data, headers=headers, timeout=timeout)
     return json.loads(res) if res else {}
 
 # %% ../nbs/03b_net.ipynb

--- a/nbs/03b_net.ipynb
+++ b/nbs/03b_net.ipynb
@@ -191,7 +191,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/net.py#L64){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/net.py#L67){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### HTTP4xxClientError\n",
        "\n",
@@ -202,7 +202,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/net.py#L64){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/net.py#L67){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### HTTP4xxClientError\n",
        "\n",
@@ -230,7 +230,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/net.py#L69){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/net.py#L72){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### HTTP5xxServerError\n",
        "\n",
@@ -241,7 +241,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/fastcore/blob/master/fastcore/net.py#L69){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/net.py#L72){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### HTTP5xxServerError\n",
        "\n",
@@ -347,7 +347,8 @@
       "====Error Body====\n",
       "{\n",
       "  \"message\": \"Not Found\",\n",
-      "  \"documentation_url\": \"https://docs.github.com/rest\"\n",
+      "  \"documentation_url\": \"https://docs.github.com/rest\",\n",
+      "  \"status\": \"404\"\n",
       "}\n",
       "\n"
      ]
@@ -387,9 +388,9 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def urljson(url, data=None, timeout=None):\n",
+    "def urljson(url, data=None, timeout=None, headers=None):\n",
     "    \"Retrieve `url` and decode json\"\n",
-    "    res = urlread(url, data=data, timeout=timeout)\n",
+    "    res = urlread(url, data=data, timeout=timeout, headers=headers)\n",
     "    return json.loads(res) if res else {}"
    ]
   },
@@ -794,13 +795,6 @@
     "from nbdev import nbdev_export\n",
     "nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/nbs/03b_net.ipynb
+++ b/nbs/03b_net.ipynb
@@ -388,9 +388,9 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def urljson(url, data=None, timeout=None, headers=None):\n",
+    "def urljson(url, data=None, headers=None, timeout=None):\n",
     "    \"Retrieve `url` and decode json\"\n",
-    "    res = urlread(url, data=data, timeout=timeout, headers=headers)\n",
+    "    res = urlread(url, data=data, headers=headers, timeout=timeout)\n",
     "    return json.loads(res) if res else {}"
    ]
   },

--- a/nbs/03b_net.ipynb
+++ b/nbs/03b_net.ipynb
@@ -795,6 +795,13 @@
     "from nbdev import nbdev_export\n",
     "nbdev_export()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Hi @jph00, I love the simplicity of `urljson` and use it often, but unfortunately it doesn't support `headers`.

Currently we can achieve the same behavior with `urlread`:

```python
urlread("https://example.com", headers={"API_KEY": key}, return_json=True)
```

but with the proposed change it becomes slightly more elegant

```python
urljson("https://example.com", headers={"API_KEY": key})
```