### PR TITLE
Add warning callout re: bool and store_true defaults

### DIFF
--- a/nbs/06_script.ipynb
+++ b/nbs/06_script.ipynb
@@ -96,6 +96,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "::: {.callout-warning}\n",
+    "## Boolean Arguments Default to False\n",
+    "Arguments of type `bool` or `store_true` default to `False` regardless of whether you provide a default or not. Use `bool_arg` as the type instead of `bool` if you want to set a default value of True. For example:\n",
+    "\n",
+    "```python\n",
+    "@call_parse\n",
+    "def main(msg:str=\"Hi\",     # The message\n",
+    "         upper:bool_arg=True): # Convert to uppercase?\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Param annotations"
    ]
   },

--- a/nbs/06_script.ipynb
+++ b/nbs/06_script.ipynb
@@ -104,7 +104,8 @@
     "@call_parse\n",
     "def main(msg:str=\"Hi\",     # The message\n",
     "         upper:bool_arg=True): # Convert to uppercase?\n",
-    "```"
+    "```\n",
+    ":::"
    ]
   },
   {


### PR DESCRIPTION
Using bool arg with default True results in the default getting over-written (see e.g. https://github.com/AnswerDotAI/fastcore/issues/533) which has confused a few people. This PR adds a small warning to the docs to use `bool_arg` instead.