### PR TITLE
test jpeg with COM segment

### DIFF
--- a/fastcore/imghdr.py
+++ b/fastcore/imghdr.py
@@ -36,8 +36,8 @@ def what(file, h=None):
 tests = []
 
 def test_jpeg(h, f):
-    """JPEG data with JFIF or Exif markers; and raw JPEG"""
-    if h[6:10] in (b'JFIF', b'Exif') or h[:4] in (b'\xff\xd8\xff\xdb',b'\xff\xd8\xff\xe2',b'\xff\xd8\xff\xe1'):
+    """JPEG data with JFIF or Exif markers; and raw JPEG including COM segments"""
+    if h[6:10] in (b'JFIF', b'Exif') or h[:4] in (b'\xff\xd8\xff\xdb',b'\xff\xd8\xff\xe2',b'\xff\xd8\xff\xe1',b'\xff\xd8\xff\xfe'):
         return 'jpeg'
 
 tests.append(test_jpeg)


### PR DESCRIPTION
## Problem Summary

**Issue**: `imghdr.what()` fails to detect valid JPEG images generated by video processing tools (like ffmpeg/libavcodec), causing `_is_img()` to return `False` even though PIL can read the images perfectly.

**Root Cause**: These programmatically generated JPEGs have a COM (comment) segment (`0xFFFE`) immediately after the SOI marker (`0xFFD8`), containing encoder metadata like "Lavc61.19.101". The existing `test_jpeg` function only checks for specific 4-byte patterns that don't include `0xFFD8FFFE`.

## Proposed Solution

Add `b'\xff\xd8\xff\xfe'` to the existing pattern list in `test_jpeg`.

## Generalization Assessment

This change is **appropriately generic** and would help many cases:

1. **Common pattern**: Video-to-image extraction tools (ffmpeg, OpenCV, etc.) routinely add COM segments
2. **Standards compliant**: COM segments are valid JPEG markers per the JPEG specification
3. **Low risk**: Adding this pattern won't cause false positives since `0xFFFE` is a reserved JPEG marker
