### PR TITLE
Patch for `NumpyDocString` to add more parameter supported classes

### DIFF
--- a/fastcore/docscrape.py
+++ b/fastcore/docscrape.py
@@ -199,8 +199,7 @@ class NumpyDocString(Mapping):
 
     def _normalize_param_section(self, val):
         """Convert lists of `Parameter` objects into a dict or clean list."""
-        if not isinstance(val, list): return val
-        if not val: return val
+        if not isinstance(val, list) or not val: return val
         if not isinstance(val[0], Parameter): return val 
         return {p.name: p for p in val} 
     


### PR DESCRIPTION
At present `docscrape.NumpyDocString` finally supports all Numpy Document Sections. However, only the `Parameters` section supports parameters. However per [`numpydoc`](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-classes) many sections should support parameters e.g. Attributes. 

This patch:

1. Adds a constant `PARAM_SECTIONS`  to note sections which support parameters.

2. Updates `NumpyDocString` to:

    - include a `param_sections` similar to `sections`,

    - normalize the parameter processing done for `NumpyDocString.sections['Parameters']` to the supported `param_sections`,
    
    - exposes configuration options to `NumpyDocString.__init__`

At present, this will prevent complaints when running `nbdev_prepare` due to `TypeError`s. For example, consider the simple class:

```python
#| export
@dataclass
class Message:
    """A single message in a conversation.
    
    Attributes
    ----------
    role : Literal["system", "user", "assistant"]
        The role of the message sender
    content : str
        The message content
    timestamp : datetime
        When the message was created
    metadata : dict
        Additional metadata (e.g., token count, model info)
    
    Examples
    --------
    >>> msg = Message(role="user", content="Hello!")
    >>> msg.role
    'user'
    """
```

Then:

```python
> showdoc.parse_docstring(Message)

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[9], [line 70](vscode-notebook-cell:?execution_count=9&line=70)
     69 parsed_data = copy.deepcopy(sections)
---> [70](vscode-notebook-cell:?execution_count=9&line=70) docscrape.NumpyDocString(docstring(Message))
     71 showdoc.parse_docstring(Message)

File ~/mamba/envs/fastcore_env/lib/python3.12/site-packages/fastcore/docscrape.py:112, in NumpyDocString.__init__(self, docstring, config)
    110 self['Parameters'] = {o.name:o for o in self['Parameters']}
    111 if self['Returns']: self['Returns'] = self['Returns'][0]
--> [112](https://file+.vscode-resource.vscode-cdn.net/Users/demo_user/Projects/NBDev_Example/nbs/doctest/~/mamba/envs/fastcore_env/lib/python3.12/site-packages/fastcore/docscrape.py:112) for section in SECTIONS: self[section] = dedent_lines(self[section], split=False)

File ~/mamba/envs/fastcore_env/lib/python3.12/site-packages/fastcore/docscrape.py:235, in dedent_lines(lines, split)
    233 def dedent_lines(lines, split=True):
    234     """Deindent a list of lines maximally"""
--> [235](https://file+.vscode-resource.vscode-cdn.net/Users/demo_user/Projects/NBDev_Example/nbs/doctest/~/mamba/envs/fastcore_env/lib/python3.12/site-packages/fastcore/docscrape.py:235)     res = textwrap.dedent("\n".join(lines))
    236     if split: res = res.split("\n")
    237     return res

TypeError: sequence item 0: expected str instance, Parameter found
```

After applying the patch:

```python
> showdoc.parse_docstring(Message)

{ 'Also': '',
  'Attributes': 'role\ncontent\ntimestamp\nmetadata',
  'Examples': '>>> msg = Message(role="user", content="Hello!")\n'
              '>>> msg.role\n'
              "'user'",
  'Extended': '',
  'Methods': '',
  'Notes': '',
  'Other': '',
  'Parameters': {},
  'Raises': '',
  'Receives': '',
  'References': '',
  'Returns': [],
  'See': '',
  'Summary': 'A single message in a conversation.',
  'Warnings': '',
  'Warns': '',
  'Yields': ''}
```

