### PR TITLE
Support setting zero and empty string as element attrs

### DIFF
--- a/fastcore/xml.py
+++ b/fastcore/xml.py
@@ -188,7 +188,7 @@ def _to_xml(elm, lvl=0, indent=True, do_escape=True):
 
     stag = tag
     if attrs:
-        sattrs = ' '.join(_to_attr(k, v) for k, v in attrs.items() if v not in (False, None, '') and (k=='_' or k[-1]!='_'))
+        sattrs = ' '.join(_to_attr(k, v) for k, v in attrs.items() if v is not False and v is not None and (k=='_' or k[-1]!='_'))
         if sattrs: stag += f' {sattrs}'
 
     cltag = '' if is_void else f'</{tag}>'

--- a/nbs/09_xml.ipynb
+++ b/nbs/09_xml.ipynb
@@ -440,7 +440,7 @@
     "\n",
     "    stag = tag\n",
     "    if attrs:\n",
-    "        sattrs = ' '.join(_to_attr(k, v) for k, v in attrs.items() if v not in (False, None, '') and (k=='_' or k[-1]!='_'))\n",
+    "        sattrs = ' '.join(_to_attr(k, v) for k, v in attrs.items() if v is not False and v is not None and (k=='_' or k[-1]!='_'))\n",
     "        if sattrs: stag += f' {sattrs}'\n",
     "\n",
     "    cltag = '' if is_void else f'</{tag}>'\n",
@@ -511,7 +511,9 @@
     "        \"<div>&lt;script&gt;alert('XSS')&lt;/script&gt;</div>\\n\")\n",
     "test_eq(to_xml(Div(\"<script>alert('XSS')</script>\"), do_escape=False),\n",
     "        \"<div><script>alert('XSS')</script></div>\\n\")\n",
-    "test_eq(to_xml(Div(foo=False), indent=False), '<div></div>')"
+    "test_eq(to_xml(Div(foo=False), indent=False), '<div></div>')\n",
+    "test_eq(to_xml(Input(type=\"number\", min=0, max=100)), '<input type=\"number\" min=\"0\" max=\"100\">\\n')\n",
+    "test_eq(to_xml(Option(\"select a value\", value=\"\")), '<option value=\"\">select a value</option>')"
    ]
   },
   {


### PR DESCRIPTION
Relates to this issue in fasthtml: https://github.com/AnswerDotAI/fasthtml/issues/567

Currently we suppress any attribute whose value is a 0 or an empty string. However there are legimitate use cases where these can these might exist.

For example
- to_xml(Input(type=\"number\", min=0, max=100))
- to_xml(Option("select a value", value="")

The former example I think is purely a bug caused by:
`v not in (False, None, '')` Python evaluates 0 == False to true so this is an edge case

Meanwhile empty strings are more debatable. Google's dom manipulation strips out the empty string leaving the value which seems to be the same as setting it to True. https://stackoverflow.com/questions/14352113/setting-an-html-option-value-to-the-empty-string

It might be fair to say that we would just expect users to pass in None if they done want that attribute showing up in the final rendering.