### PR TITLE
Fix `store_attr` to preserve existing instance attributes

### DIFF
--- a/fastcore/basics.py
+++ b/fastcore/basics.py
@@ -458,7 +458,7 @@ def store_attr(names=None, self=None, but='', cast=False, store_args=None, **att
     anno = annotations(self) if cast else {}
     if names and isinstance(names,str): names = re.split(', *', names)
     ns = names if names is not None else getattr(self, '__slots__', args[1:])
-    added = {n:fr.f_locals[n] for n in ns}
+    added = {n: getattr(self, n, fr.f_locals[n]) for n in ns}
     attrs = {**attrs, **added}
     if isinstance(but,str): but = re.split(', *', but)
     attrs = {k:v for k,v in attrs.items() if k not in but}

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -1215,7 +1215,31 @@
    "execution_count": null,
    "id": "da11467b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "---\n",
+       "\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/basics.py#L198){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "\n",
+       "### Inf\n",
+       "\n",
+       ">      Inf ()\n",
+       "\n",
+       "*Infinite lists*"
+      ],
+      "text/plain": [
+       ">      Inf ()\n",
+       "\n",
+       "*Infinite lists*"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "show_doc(Inf);"
    ]
@@ -2355,7 +2379,7 @@
     "    anno = annotations(self) if cast else {}\n",
     "    if names and isinstance(names,str): names = re.split(', *', names)\n",
     "    ns = names if names is not None else getattr(self, '__slots__', args[1:])\n",
-    "    added = {n:fr.f_locals[n] for n in ns}\n",
+    "    added = {n: getattr(self, n, fr.f_locals[n]) for n in ns}\n",
     "    attrs = {**attrs, **added}\n",
     "    if isinstance(but,str): but = re.split(', *', but)\n",
     "    attrs = {k:v for k,v in attrs.items() if k not in but}\n",
@@ -2485,6 +2509,24 @@
     "\n",
     "t = _T(1,b=3)\n",
     "assert t.a==1 and t.b==3 and t.c==2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe78248d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "#| hide\n",
+    "class T_:\n",
+    "    def __init__(self, a, b, c):\n",
+    "        self.a = a - 1\n",
+    "        store_attr()\n",
+    "\n",
+    "t = T_(5, 2, 3)\n",
+    "assert t.a==4 and t.b==2 and t.c==3"
    ]
   },
   {
@@ -6825,7 +6867,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1140){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/basics.py#L1158){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### PrettyString\n",
        "\n",
@@ -6834,12 +6876,6 @@
        "*Little hack to get strings to show properly in Jupyter.*"
       ],
       "text/plain": [
-       "---\n",
-       "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/basics.py#L1140){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
-       "\n",
-       "#### PrettyString\n",
-       "\n",
        "\n",
        "\n",
        "*Little hack to get strings to show properly in Jupyter.*"
@@ -6969,7 +7005,7 @@
     {
      "data": {
       "text/plain": [
-       "22"
+       "24"
       ]
      },
      "execution_count": null,
@@ -7530,10 +7566,6 @@
        "*Same as `get_ipython` but returns `False` if not in IPython*"
       ],
       "text/plain": [
-       "---\n",
-       "\n",
-       "### ipython_shell\n",
-       "\n",
        ">      ipython_shell ()\n",
        "\n",
        "*Same as `get_ipython` but returns `False` if not in IPython*"
@@ -7566,10 +7598,6 @@
        "*Check if code is running in some kind of IPython environment*"
       ],
       "text/plain": [
-       "---\n",
-       "\n",
-       "### in_ipython\n",
-       "\n",
        ">      in_ipython ()\n",
        "\n",
        "*Check if code is running in some kind of IPython environment*"
@@ -7602,10 +7630,6 @@
        "*Check if the code is running in Google Colaboratory*"
       ],
       "text/plain": [
-       "---\n",
-       "\n",
-       "### in_colab\n",
-       "\n",
        ">      in_colab ()\n",
        "\n",
        "*Check if the code is running in Google Colaboratory*"
@@ -7638,10 +7662,6 @@
        "*Check if the code is running in a jupyter notebook*"
       ],
       "text/plain": [
-       "---\n",
-       "\n",
-       "### in_jupyter\n",
-       "\n",
        ">      in_jupyter ()\n",
        "\n",
        "*Check if the code is running in a jupyter notebook*"
@@ -7674,10 +7694,6 @@
        "*Check if the code is running in a jupyter notebook*"
       ],
       "text/plain": [
-       "---\n",
-       "\n",
-       "### in_notebook\n",
-       "\n",
        ">      in_notebook ()\n",
        "\n",
        "*Check if the code is running in a jupyter notebook*"
@@ -7749,13 +7765,7 @@
    "source": []
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "python3",
-   "language": "python",
-   "name": "python3"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
Fixes #496

`store_attr` now checks if an attribute already exists on `self` before storing, preserving any modifications made before calling `store_attr()`.

**Before:**
```python
class T_:
    def __init__(self, a, b, c):
        self.a = a - 1
        store_attr()  # self.a gets overwritten back to original 'a'
```

**After:**
```python
class T_:
    def __init__(self, a, b, c):
        self.a = a - 1
        store_attr()  # self.a stays as a - 1
```

The fix uses `getattr(self, n, fr.f_locals[n])` to prefer existing attribute values over the original arguments.