### PR TITLE
add slice support for L assignment

### DIFF
--- a/fastcore/foundation.py
+++ b/fastcore/foundation.py
@@ -139,8 +139,7 @@ class L(GetAttr, CollBase, metaclass=_L_Meta):
 
     def __setitem__(self, idx, o):
         "Set `idx` (can be list of indices, or mask, or int) items to `o` (which is broadcast if not iterable)"
-        if isinstance(idx, int): self.items[idx] = o
-        elif isinstance(idx, slice): self.items[idx] = o
+        if isinstance(idx, int) or isinstance(idx, slice): self.items[idx] = o
         else:
             idx = idx if isinstance(idx,L) else listify(idx)
             if not is_iter(o): o = [o]*len(idx)

--- a/nbs/02_foundation.ipynb
+++ b/nbs/02_foundation.ipynb
@@ -295,7 +295,7 @@
        "*Test whether `o` can be used in a `for` loop*"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -524,7 +524,7 @@
        "60"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -545,7 +545,7 @@
        "1"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -566,7 +566,7 @@
        "0"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -618,7 +618,7 @@
        "[0, 0, 1, 0, 1, 2]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -647,7 +647,7 @@
        "[['hello', 'world'], ['foo', 'bar']]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -668,7 +668,7 @@
        "['hello', 'world', 'flatmap', 'rocks']"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -705,7 +705,7 @@
        "['a', 'b', 'c', 'd', 'e']"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -734,7 +734,7 @@
        "[10, 20]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -755,7 +755,7 @@
        "['a@x.com', 'b@x.com', 'c@x.com']"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -791,7 +791,7 @@
        " Path('images/puppy.jpg')]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -820,7 +820,7 @@
        "[(6, 1), (6, 2), (6, 3), (6, 6), (10, 1), (10, 2), (10, 5), (10, 10)]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -937,8 +937,7 @@
     "\n",
     "    def __setitem__(self, idx, o):\n",
     "        \"Set `idx` (can be list of indices, or mask, or int) items to `o` (which is broadcast if not iterable)\"\n",
-    "        if isinstance(idx, int): self.items[idx] = o\n",
-    "        elif isinstance(idx, slice): self.items[idx] = o\n",
+    "        if isinstance(idx, int) or isinstance(idx, slice): self.items[idx] = o\n",
     "        else:\n",
     "            idx = idx if isinstance(idx,L) else listify(idx)\n",
     "            if not is_iter(o): o = [o]*len(idx)\n",
@@ -1040,7 +1039,7 @@
        "[1, 2, 3, 'j', 4, 'k', 6, 7, 8, 9, 10, 11]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1100,7 +1099,7 @@
        "[6, 11, 1]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1314,7 +1313,7 @@
        "*Retrieve `idx` (can be list of indices, or mask, or int) items*"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1363,7 +1362,7 @@
        "*Set `idx` (can be list of indices, or mask, or int) items to `o` (which is broadcast if not iterable)*"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1726,7 +1725,7 @@
        "[['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1760,7 +1759,7 @@
        "[[1, 2, 3], [4, 5, 6], [7, 8, 9]]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1792,7 +1791,7 @@
        "       [7, 8, 9]])"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1834,7 +1833,7 @@
        "[['a', 'b', 'c'], ['d', 'e']]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1889,7 +1888,7 @@
        "[{'a': ['a1', 'a3'], 'b': ['b2']}, {'x': ['x1', 'x3'], 'y': ['y2']}]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1952,7 +1951,7 @@
        "[[2, 12], [30, 56]]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2016,7 +2015,7 @@
        "[['1x', '2y'], ['3z']]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2210,7 +2209,7 @@
        "[[1, 2, 3], [4, 5, 6], [7, 8, 9]]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2231,7 +2230,7 @@
        "[[], [5, 6], [7, 8, 9]]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2296,7 +2295,7 @@
        "[[(1, 5)], [(4, 6)]]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2487,7 +2486,7 @@
        "[2, 1, None]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2671,7 +2670,7 @@
        "[[(1, 'a'), (2, 'b'), (3, 'c')], [(4, 'd'), (6, 'f')]]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2685,9 +2684,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1c21919b",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.253296+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2710,9 +2707,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "74a73a56",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.274713+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L((3,1),(1,2),(2,0)).starsorted(operator.sub), [(1,2),(3,1),(2,0)])  # sorted by a-b: 2, 2, -1\n",
@@ -2723,9 +2718,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7549144e",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.307266+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2748,9 +2741,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7123a1a2",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.338182+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L((1,3),(2,1),(0,2)).rstarsorted(operator.sub), [(2,1),(1,3),(0,2)])  # sorted by b-a: 0, 2, 2\n",
@@ -2761,9 +2752,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9d86b896",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.368046+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2777,9 +2766,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6c74fb84",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.403691+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L([0,1,2,3],4,L(5,6)).concat(), range(7))"
@@ -2789,9 +2776,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b493aad4",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.435992+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2805,9 +2790,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b4aaf8fa",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.472377+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "t = L([0,1,2,3],4,L(5,6)).copy()\n",
@@ -2818,9 +2801,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7b2691d6",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.499369+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2844,9 +2825,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3edd22b5",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.524798+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "t = L(1,2,3,4,5)\n",
@@ -2859,9 +2838,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7b83c9e9",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.551997+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2876,9 +2853,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bd4184ca",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.610312+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4).reduce(operator.add), 10)\n",
@@ -2897,9 +2872,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "65b58b72",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.641874+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2907,7 +2880,7 @@
        "[6, 9, 30]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2921,9 +2894,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3db27a6a",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.667692+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -2947,9 +2918,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "41fd24f2",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.701676+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L((1,2),(3,4),(5,6)).starreduce(lambda acc,a,b: acc+a*b, 0), 44)  # 0+1*2+3*4+5*6\n",
@@ -2968,9 +2937,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dfe97eec",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.734049+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2978,7 +2945,7 @@
        "44"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2992,9 +2959,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "046f01fb",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.760747+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3018,9 +2983,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "84b3413b",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.791415+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3034,9 +2997,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "18e6c336",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.822976+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4).sum(), 10)\n",
@@ -3047,9 +3008,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2a96a0fd",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.858795+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3063,9 +3022,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a41eb5c0",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.888142+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4).product(), 24)\n",
@@ -3076,9 +3033,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f82d9975",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.983803+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3092,9 +3047,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6d29b6c6",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:58.984797+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "t = L(0,1,2,3)\n",
@@ -3105,9 +3058,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1366f0fa",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.020003+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3121,9 +3072,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ca54000c",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.047190+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "t = L(SimpleNamespace(),SimpleNamespace())\n",
@@ -3135,9 +3084,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ab6bb396",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.076702+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3159,9 +3106,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7f23af48",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.112897+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(\"a,b,c\", \"d,e\").flatmap(Self.split(',')), ['a', 'b', 'c', 'd', 'e'])"
@@ -3179,9 +3124,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "98639cc7",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.143483+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3189,7 +3132,7 @@
        "['a', 'b', 'c', 'd', 'e']"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3210,9 +3153,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9c927236",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.182629+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3234,9 +3175,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "816b9e9c",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.214482+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(list(itertools.islice(L(1,2,3).cycle(), 7)), [1,2,3,1,2,3,1])"
@@ -3246,9 +3185,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "79e84e6d",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.241486+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3271,9 +3208,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6b80039c",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.275110+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4,5,1,2).takewhile(lambda x: x<4), [1,2,3])\n",
@@ -3292,9 +3227,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da17275d",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.351824+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3302,7 +3235,7 @@
        "[[1, 2], [2, 3], []]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3316,9 +3249,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c9f6e354",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.353354+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3341,9 +3272,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "086eec4a",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.375798+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4,5,1,2).dropwhile(lt(4)), [4,5,1,2])\n",
@@ -3354,9 +3283,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "45f04c5c",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.403174+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3379,9 +3306,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "14007659",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.435197+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L((1,2),(2,3),(4,1),(5,6)).startakewhile(lambda a,b: a<b), [(1,2),(2,3)])\n",
@@ -3392,9 +3317,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "83fa9180",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.462657+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3402,7 +3325,7 @@
        "[[(1, 5), (2, 6)], [(0, 1)]]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3416,9 +3339,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f64504c1",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.499820+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3441,9 +3362,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "88467916",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.530267+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L((2,1),(3,2),(1,4),(6,5)).rstartakewhile(lt), [(2,1),(3,2)])  # 1<2, 2<3, 4<1 fails\n",
@@ -3454,9 +3373,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6544466c",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.567970+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3479,9 +3396,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1c611ab3",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.591856+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L((1,2),(2,3),(4,1),(5,6)).stardropwhile(lambda a,b: a<b), [(4,1),(5,6)])\n",
@@ -3492,9 +3407,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "91f75f7d",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.620831+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3517,9 +3430,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "17ef03a4",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.651815+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L((2,1),(3,2),(1,4),(6,5)).rstardropwhile(lt), [(1,4),(6,5)])  # 1<2, 2<3 pass, 4<1 fails\n",
@@ -3530,9 +3441,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "53cf2acc",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.717517+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3555,9 +3464,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "848d116e",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.741415+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4).accumulate(), [1,3,6,10])\n",
@@ -3577,9 +3484,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2f2be97f",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.772094+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3587,7 +3492,7 @@
        "[[1, 2, 6], [4, 20, 120], [10, 200]]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3601,9 +3506,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c55df328",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.807801+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3625,9 +3528,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d289d7cb",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.838036+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4).pairwise(), [(1,2),(2,3),(3,4)])\n",
@@ -3638,9 +3539,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1f2a370c",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.865520+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3656,9 +3555,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "41aefe58",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.898252+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3670,9 +3567,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d9f7ffb9",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.933349+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3694,9 +3589,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f890dfb1",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.957809+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4,5).batched(2), [(1,2),(3,4),(5,)])\n",
@@ -3707,9 +3600,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9e996aec",
-   "metadata": {
-    "time_run": "2025-12-31T17:27:59.982183+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3731,9 +3622,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9fc0aeb9",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.089328+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(list('abcd')).compress([1,0,1,0]), ['a','c'])\n",
@@ -3744,9 +3633,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "051afac0",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.090402+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3768,9 +3655,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9af6fa5e",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.112965+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3).permutations(), [(1,2,3),(1,3,2),(2,1,3),(2,3,1),(3,1,2),(3,2,1)])\n",
@@ -3781,9 +3666,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "63066166",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.150477+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3805,9 +3688,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6d3bd5bf",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.181820+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L(1,2,3,4).combinations(2), [(1,2),(1,3),(1,4),(2,3),(2,4),(3,4)])\n",
@@ -3818,9 +3699,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f29ba907",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.215660+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3845,9 +3724,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3ccae0ec",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.251036+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "t,f = L(1,2,3,4,5,6).partition(lambda x: x%2==0)\n",
@@ -3871,9 +3748,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "56844860",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.273098+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3881,7 +3756,7 @@
        "[([], [1, 2, 3, 4, 5]), ([10, 15, 20, 25], []), ([6, 9], [3])]"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3895,9 +3770,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2dd5af2f",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.304856+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3922,9 +3795,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e1b9f7f6",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.329185+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "asc,desc = L((1,2),(3,1),(2,4),(5,3)).starpartition(lt)\n",
@@ -3936,9 +3807,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "63c70884",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.363967+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -3963,9 +3832,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "58127227",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.458575+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "asc,desc = L((2,1),(1,3),(4,2),(3,5)).rstarpartition(lt)\n",
@@ -3977,9 +3844,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3c269425",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.459581+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -4005,9 +3870,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a5f233d2",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.488314+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(L([[1,2],[3,[4,5]]]).flatten(), [1,2,3,4,5])\n",
@@ -4028,9 +3891,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8e2bafde",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.524315+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -4045,9 +3906,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "08333fdc",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.556925+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -4069,9 +3928,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "964cf19a",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.591081+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4083,7 +3940,7 @@
        " 'some_num': '3'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4101,9 +3958,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e06640e8",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.623376+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
@@ -4164,9 +4019,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "219b1aec",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.647403+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4174,7 +4027,7 @@
        "{'user': 'fastai', 'lib_name': 'fastcore', 'some_path': 'test', 'some_bool': 'True', 'some_num': '3'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4198,9 +4051,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d99a56cd",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.675814+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4208,7 +4059,7 @@
        "{'user': 'fastai', 'lib_name': 'fastcore', 'some_path': 'test', 'some_bool': 'True', 'some_num': '3'}"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4231,9 +4082,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1f7282b8",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.708777+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cfg = Config('..', 'tmp.ini', create=_d, save=False)\n",
@@ -4253,9 +4102,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f8bd60db",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.742985+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create a complete example config file with comments\n",
@@ -4284,9 +4131,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5143b482",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.848407+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Now read it back to verify\n",
@@ -4300,9 +4145,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2341d0b5",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.849313+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4319,7 +4162,7 @@
        ">      Config.get (k, default=None)"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4340,9 +4183,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1f30f8eb",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.877682+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_eq(cfg.user,'fastai')\n",
@@ -4362,9 +4203,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6c124f0f",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.901064+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with tempfile.TemporaryDirectory() as d:\n",
@@ -4386,9 +4225,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c3ab1e1d",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.927290+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "_types = dict(some_path=Path, some_bool=bool, some_num=int)\n",
@@ -4403,9 +4240,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1542e621",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.965697+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4426,7 +4261,7 @@
        "*Search `cfg_path` and its parents to find `cfg_name`*"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4447,9 +4282,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5f858954",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:00.990969+00:00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4457,7 +4290,7 @@
        "'fastcore'"
       ]
      },
-     "execution_count": 0,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4478,9 +4311,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "68064341",
-   "metadata": {
-    "time_run": "2025-12-31T17:28:01.021798+00:00"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#| hide\n",
@@ -4488,10 +4319,7 @@
    ]
   }
  ],
- "metadata": {
-  "solveit_dialog_mode": "learning",
-  "solveit_ver": 2
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
This PR allows for `L` objects to now handle slice assignments:

```python
lst = L([1, 2, 3, 3, 4, 5])
lst[1:1] = [10, 20]
lst
# [1, 10, 20, 2, 3, 3, 4, 5]
```