### PR TITLE
Fix anno typing when `eval_str=True`

### DIFF
--- a/fastcore/docments.py
+++ b/fastcore/docments.py
@@ -100,11 +100,12 @@ def _get_comment(line, arg, comments, parms):
         line -= 1
     return dedent('\n'.join(reversed(res))) if res else None
 
-def _get_full(p, docs):
+def _get_full(p, docs, eval_str=False):
     anno = p.annotation
     if anno==empty:
         if p.default!=empty: anno = type(p.default)
         elif p.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD): anno = p.kind
+        elif eval_str: anno = None
     return AttrDict(docment=docs.get(p.name), anno=anno, default=p.default)
 
 # %% ../nbs/04_docments.ipynb
@@ -159,7 +160,7 @@ def docments(s, full=False, eval_str=False, returns=True, args_kwargs=False):
             if v not in docs: docs[v] = _get_comment(k, v, c, p)
         s = getattr(s, '__delwrap__', None)
     
-    res = {k:_get_full(v, docs) if full else docs.get(k) for k,v in sig.parameters.items()}
+    res = {k:_get_full(v, docs, eval_str=eval_str) if full else docs.get(k) for k,v in sig.parameters.items()}
     if returns:
         if full: res['return'] = AttrDict(docment=docs.get('return'), anno=sig.return_annotation, default=empty)
         else: res['return'] = docs.get('return')

--- a/nbs/04_docments.ipynb
+++ b/nbs/04_docments.ipynb
@@ -329,11 +329,12 @@
     "        line -= 1\n",
     "    return dedent('\\n'.join(reversed(res))) if res else None\n",
     "\n",
-    "def _get_full(p, docs):\n",
+    "def _get_full(p, docs, eval_str=False):\n",
     "    anno = p.annotation\n",
     "    if anno==empty:\n",
     "        if p.default!=empty: anno = type(p.default)\n",
     "        elif p.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD): anno = p.kind\n",
+    "        elif eval_str: anno = None\n",
     "    return AttrDict(docment=docs.get(p.name), anno=anno, default=p.default)"
    ]
   },
@@ -658,7 +659,7 @@
     "            if v not in docs: docs[v] = _get_comment(k, v, c, p)\n",
     "        s = getattr(s, '__delwrap__', None)\n",
     "    \n",
-    "    res = {k:_get_full(v, docs) if full else docs.get(k) for k,v in sig.parameters.items()}\n",
+    "    res = {k:_get_full(v, docs, eval_str=eval_str) if full else docs.get(k) for k,v in sig.parameters.items()}\n",
     "    if returns:\n",
     "        if full: res['return'] = AttrDict(docment=docs.get('return'), anno=sig.return_annotation, default=empty)\n",
     "        else: res['return'] = docs.get('return')\n",
@@ -1842,7 +1843,7 @@
        "| **Returns** | **int** |  |  |"
       ],
       "text/plain": [
-       "DocmentTbl(obj=<function _f at 0x134bf1440>, dm={'a': {'docment': 'description of param a', 'anno': <class 'inspect._empty'>, 'default': <class 'inspect._empty'>}, 'b': {'docment': 'description of param b', 'anno': <class 'bool'>, 'default': True}, 'c': {'docment': <class 'inspect._empty'>, 'anno': <class 'str'>, 'default': None}, 'return': {'docment': <class 'inspect._empty'>, 'anno': <class 'int'>, 'default': <class 'inspect._empty'>}}, verbose=True, returns=True, params=['a', 'b', 'c'])"
+       "DocmentTbl(obj=<function _f at 0x131f0efc0>, dm={'a': {'docment': 'description of param a', 'anno': <class 'inspect._empty'>, 'default': <class 'inspect._empty'>}, 'b': {'docment': 'description of param b', 'anno': <class 'bool'>, 'default': True}, 'c': {'docment': <class 'inspect._empty'>, 'anno': <class 'str'>, 'default': None}, 'return': {'docment': <class 'inspect._empty'>, 'anno': <class 'int'>, 'default': <class 'inspect._empty'>}}, verbose=True, returns=True, params=['a', 'b', 'c'])"
       ]
      },
      "execution_count": null,
@@ -1920,7 +1921,7 @@
        "| **Returns** | **str** |  | **Result of doing it** |"
       ],
       "text/plain": [
-       "DocmentTbl(obj=<function _f at 0x134b9b600>, dm={'a': {'docment': <class 'inspect._empty'>, 'anno': <class 'inspect._empty'>, 'default': <class 'inspect._empty'>}, 'b': {'docment': 'param b', 'anno': <class 'int'>, 'default': <class 'inspect._empty'>}, 'c': {'docment': 'param c', 'anno': <class 'str'>, 'default': 'foo'}, 'return': {'docment': 'Result of doing it', 'anno': <class 'str'>, 'default': <class 'inspect._empty'>}}, verbose=True, returns=True, params=['a', 'b', 'c'])"
+       "DocmentTbl(obj=<function _f at 0x131f0f060>, dm={'a': {'docment': <class 'inspect._empty'>, 'anno': <class 'inspect._empty'>, 'default': <class 'inspect._empty'>}, 'b': {'docment': 'param b', 'anno': <class 'int'>, 'default': <class 'inspect._empty'>}, 'c': {'docment': 'param c', 'anno': <class 'str'>, 'default': 'foo'}, 'return': {'docment': 'Result of doing it', 'anno': <class 'str'>, 'default': <class 'inspect._empty'>}}, verbose=True, returns=True, params=['a', 'b', 'c'])"
       ]
      },
      "execution_count": null,
@@ -2013,7 +2014,7 @@
        "| d | bool | True | description of param d |"
       ],
       "text/plain": [
-       "DocmentTbl(obj=<function _Test.foo at 0x134b9a840>, dm={'c': {'docment': 'description of param c', 'anno': <class 'int'>, 'default': <class 'inspect._empty'>}, 'd': {'docment': 'description of param d', 'anno': <class 'bool'>, 'default': True}, 'return': {'docment': <class 'inspect._empty'>, 'anno': <class 'inspect._empty'>, 'default': <class 'inspect._empty'>}}, verbose=True, returns=True, params=['self', 'c', 'd'])"
+       "DocmentTbl(obj=<function _Test.foo at 0x131e5c040>, dm={'c': {'docment': 'description of param c', 'anno': <class 'int'>, 'default': <class 'inspect._empty'>}, 'd': {'docment': 'description of param d', 'anno': <class 'bool'>, 'default': True}, 'return': {'docment': <class 'inspect._empty'>, 'anno': <class 'inspect._empty'>, 'default': <class 'inspect._empty'>}}, verbose=True, returns=True, params=['self', 'c', 'd'])"
       ]
      },
      "execution_count": null,
@@ -2521,7 +2522,13 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
This PR fixes an issue with `docments` annotation type evaluation. 

When calling `docments(full=True, eval_str=True)`, empty annotation types in the output are not evaluated to `None` as they once were, causing issues in other functions that use `docments` for type setting (like `@call_parse`).

Testing was done using the `watch_export` cli, which would throw errors regarding `inspect._empty` not being a valid type previously. With this change it works as before