### PR TITLE
Fix f-string error (python3.11)

### DIFF
--- a/fastcore/docments.py
+++ b/fastcore/docments.py
@@ -356,7 +356,8 @@ class DocmentText(_DocmentBase):
                 curr.append(fmt)
                 if doc: lines.append(', '.join(curr) + ',' + comment); curr = []
             if curr: lines.append(', '.join(curr))
-            sig_str = f"def {get_name(self.obj)}(\n    {'\n    '.join(lines)}\n{self._ret_str}"
+            params = '\n    '.join(lines)
+            sig_str = f"def {get_name(self.obj)}(\n    {params}\n{self._ret_str}"
         docstr = f'    "{self.obj.__doc__}"' if self.docstring and self.obj.__doc__ else ''
         return f"{sig_str}\n{docstr}"
     


### PR DESCRIPTION
SyntaxError: f-string expression part cannot include a backslash
Reproduces in python 3.11
<img width="974" height="303" alt="image" src="https://github.com/user-attachments/assets/478b56e8-69cd-4b72-9152-1202aa7e7dc7" />

example: https://github.com/Nayjest/Gito/actions/runs/21119982350/job/60731206657?pr=140