### PR TITLE
Return None from detect_mime for non-bytes input

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -193,6 +193,7 @@ _sigs = {
 
 def detect_mime(data):
     "Get the MIME type for bytes `data`, covering common PDF, audio, video, and image types"
+    if not isinstance(data,bytes): return None
     import mimetypes
     from fastcore import imghdr
     for (sig,pos),mime in _sigs.items():

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -582,7 +582,7 @@
     {
      "data": {
       "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAyADIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDi6KKK+ZP3EKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA//Z",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAZ0lEQVR4Ae3SsREAIAzEsMD+O8MM7lKI+ouc8Hmz8d2NR804q/wLLVpFoGy1RasIlK22aBWBstUWrSJQttqiVQTKVlu0ikDZaotWEShbbdEqAmWrLVpFoGy1RasIlK22aBWBstVW0fpBqgFjLbA8fgAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAfUlEQVR4AWL8zzAYAdNgdBTDqLNIAqORSAoYDS1SwGhokQJGQ4sUMBpapIDR0CIFjIYWKWA0tEgBo6FFChgNLVLAaGiRAkZDixQwGlqkgNHQIgWMhhYpYDS0SAGjoUUKGA0tUsBoaJECRkOLFDAaWqSA0dAiBYyGFmCkhBYAQaoBY/NmMJ4AAAAASUVORK5CYII=",
       "text/plain": [
        "<PIL.Image.Image image mode=RGB size=50x50>"
       ]
@@ -621,7 +621,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAS0lEQVR4nO3OsQEAEADAMPz/Mw9YMjE0F2Tu8aP1OnBXS9QStUQtUUvUErVELVFL1BK1RC1RS9QStUQtUUvUErVELVFL1BK1RC1xAEGqAWOFuDKrAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAZklEQVR4nM3OMQEAMAyAMIZ/z52B/iUK8oYiSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkrwO7D0GqAWPcq78HAAAAAElFTkSuQmCC",
       "text/plain": [
        "<IPython.core.display.Image object>"
       ]
@@ -662,6 +662,7 @@
     "\n",
     "def detect_mime(data):\n",
     "    \"Get the MIME type for bytes `data`, covering common PDF, audio, video, and image types\"\n",
+    "    if not isinstance(data,bytes): return None\n",
     "    import mimetypes\n",
     "    from fastcore import imghdr\n",
     "    for (sig,pos),mime in _sigs.items():\n",
@@ -672,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95c46f5a",
+   "id": "9e314cb9",
    "metadata": {},
    "outputs": [
     {
@@ -688,6 +689,16 @@
    ],
    "source": [
     "detect_mime(ib)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ec0b74c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_is(detect_mime('this is a non-byte string'),None)"
    ]
   },
   {
@@ -1029,7 +1040,7 @@
     {
      "data": {
       "text/plain": [
-       "'pip 25.3 from /Users/jhoward/aai-ws/.venv/lib/python3.12/site-packages/pip (python 3.12)'"
+       "'pip 25.3 from /Users/rensdimmendaal/git/.venv/lib/python3.12/site-packages/pip (python 3.12)'"
       ]
      },
      "execution_count": null,
@@ -1607,7 +1618,7 @@
     {
      "data": {
       "text/plain": [
-       "Path('/Users/jhoward/aai-ws/fastcore/fastcore')"
+       "Path('/Users/rensdimmendaal/git/repos/fastcore/fastcore')"
       ]
      },
      "execution_count": null,
@@ -1912,14 +1923,14 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L499){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L500){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ReindexCollection\n",
        "\n",
        "```python\n",
        "\n",
        "def ReindexCollection(\n",
-       "    coll, idxs:NoneType=None, cache:NoneType=None, tfm:function=<function noop>\n",
+       "    coll, idxs:NoneType=None, cache:NoneType=None, tfm:function=noop\n",
        "):\n",
        "\n",
        "\n",
@@ -1931,7 +1942,7 @@
        "```python\n",
        "\n",
        "def ReindexCollection(\n",
-       "    coll, idxs:NoneType=None, cache:NoneType=None, tfm:function=<function noop>\n",
+       "    coll, idxs:NoneType=None, cache:NoneType=None, tfm:function=noop\n",
        "):\n",
        "\n",
        "\n",
@@ -2008,7 +2019,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L510){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L511){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "###### ReindexCollection.reindex\n",
        "\n",
@@ -2121,7 +2132,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L514){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L515){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "##### ReindexCollection.cache_clear\n",
        "\n",
@@ -2196,7 +2207,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L511){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L512){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "##### ReindexCollection.shuffle\n",
        "\n",
@@ -2250,7 +2261,7 @@
     {
      "data": {
       "text/plain": [
-       "['b', 'a', 'g', 'h', 'd', 'e', 'c', 'f']"
+       "['a', 'g', 'h', 'c', 'd', 'b', 'f', 'e']"
       ]
      },
      "execution_count": null,
@@ -2646,7 +2657,7 @@
     {
      "data": {
       "text/plain": [
-       "'_7WDcaL3JT7qV037u3Werzw'"
+       "'_xNpj56ekTqyk9MsVDYRnnA'"
       ]
      },
      "execution_count": null,
@@ -2741,7 +2752,7 @@
     {
      "data": {
       "text/plain": [
-       "('408ea190', '8c7d7247')"
+       "('0100dd53', '8c7d7247')"
       ]
      },
      "execution_count": null,
@@ -3438,7 +3449,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L712){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L713){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### EventTimer\n",
        "\n",
@@ -3493,8 +3504,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Num Events: 1, Freq/sec: 73.6\n",
-      "Most recent:  ▁▁▂▅▇ 33.0 26.9 54.1 89.8 120.6\n"
+      "Num Events: 9, Freq/sec: 346.2\n",
+      "Most recent:  ▅▃▇▁▇ 263.7 256.6 278.3 235.1 276.9\n"
      ]
     }
    ],
@@ -3578,7 +3589,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L744){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L745){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### PartialFormatter\n",
        "\n",
@@ -3722,7 +3733,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2000-01-01 12:00:00 UTC is 2000-01-01 22:00:00+10:00 local time\n"
+      "2000-01-01 12:00:00 UTC is 2000-01-01 13:00:00+01:00 local time\n"
      ]
     }
    ],
@@ -3754,7 +3765,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2000-01-01 12:00:00 local is 2000-01-01 02:00:00+00:00 UTC time\n"
+      "2000-01-01 12:00:00 local is 2000-01-01 11:00:00+00:00 UTC time\n"
      ]
     }
    ],
@@ -3863,7 +3874,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L807){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/xtras.py#L808){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "#### ContextManagers\n",
        "\n",


### PR DESCRIPTION
W this pr `detect_mime` returns `None` if the inputs are not `bytes` instead of raising an error. 
It already returns `None` if no mimetype was found in the bytes input.

I noticed I was doing checks for `isinstance(data, bytes)` or putting it in a `try/except` block when using this function and I figured it might be better to handle this case in here instead.