### PR TITLE
Improve case convertion performance

### DIFF
--- a/fastcore/basics.py
+++ b/fastcore/basics.py
@@ -473,13 +473,13 @@ _camel_re2 = re.compile('([a-z0-9])([A-Z])')
 # %% ../nbs/01_basics.ipynb #dd737e81
 def camel2words(s, space=' '):
     "Convert CamelCase to 'spaced words'"
-    return re.sub(_c2w_re, rf'{space}\1', s)
+    return _c2w_re.sub(rf'{space}\1', s)
 
 # %% ../nbs/01_basics.ipynb #a588a317
 def camel2snake(name):
     "Convert CamelCase to snake_case"
-    s1   = re.sub(_camel_re1, r'\1_\2', name)
-    return re.sub(_camel_re2, r'\1_\2', s1).lower()
+    s1   = _camel_re1.sub(r'\1_\2', name)
+    return _camel_re2.sub(r'\1_\2', s1).lower()
 
 # %% ../nbs/01_basics.ipynb #bbd632b4
 def snake2camel(s):

--- a/nbs/01_basics.ipynb
+++ b/nbs/01_basics.ipynb
@@ -2776,7 +2776,7 @@
     "#| export\n",
     "def camel2words(s, space=' '):\n",
     "    \"Convert CamelCase to 'spaced words'\"\n",
-    "    return re.sub(_c2w_re, rf'{space}\\1', s)"
+    "    return _c2w_re.sub(rf'{space}\\1', s)"
    ]
   },
   {
@@ -2799,8 +2799,8 @@
     "#| export\n",
     "def camel2snake(name):\n",
     "    \"Convert CamelCase to snake_case\"\n",
-    "    s1   = re.sub(_camel_re1, r'\\1_\\2', name)\n",
-    "    return re.sub(_camel_re2, r'\\1_\\2', s1).lower()"
+    "    s1   = _camel_re1.sub(r'\\1_\\2', name)\n",
+    "    return _camel_re2.sub(r'\\1_\\2', s1).lower()"
    ]
   },
   {


### PR DESCRIPTION
Recently I had to run `camel2snake` for many json documents and noticed that calling `re.sub(re_pat, ...)` is slower than calling `re_pat.sub(...)`.

From what I found, calling `re.sub` have to check if `re_pat` is a compiled pattern first.

```python
import timeit

setup = """
import re
_camel_re1 = re.compile('(.)([A-Z][a-z]+)')
x = 'camelCaseString'
"""

t1 = timeit.timeit("re.sub(_camel_re1, r'\\1_\\2', x)", setup=setup, number=1_000_000)
t2 = timeit.timeit("_camel_re1.sub(r'\\1_\\2', x)", setup=setup, number=1_000_000)

print(f"re.sub(_camel_re1, ...): {t1:.3f}s")
print(f"_camel_re1.sub(...):   {t2:.3f}s")
```

Gives:
```
re.sub(_camel_re1, ...): 1.410s
_camel_re1.sub(...):   0.675s
```