### PR TITLE
fix urlretrieve NameError by importing tempfile

### DIFF
--- a/fastcore/net.py
+++ b/fastcore/net.py
@@ -22,7 +22,7 @@ from .utils import *
 from .parallel import *
 
 from functools import wraps
-import json,urllib,contextlib
+import json,urllib,contextlib,tempfile
 import socket,urllib.request,http,urllib
 from contextlib import contextmanager,ExitStack
 from urllib.request import Request,urlretrieve,install_opener,HTTPErrorProcessor,HTTPRedirectHandler

--- a/nbs/03b_net.ipynb
+++ b/nbs/03b_net.ipynb
@@ -22,7 +22,7 @@
     "from fastcore.parallel import *\n",
     "\n",
     "from functools import wraps\n",
-    "import json,urllib,contextlib\n",
+    "import json,urllib,contextlib,tempfile\n",
     "import socket,urllib.request,http,urllib\n",
     "from contextlib import contextmanager,ExitStack\n",
     "from urllib.request import Request,urlretrieve,install_opener,HTTPErrorProcessor,HTTPRedirectHandler\n",


### PR DESCRIPTION
Calling `urlretrieve` after `from fastcore.net import *` fails inside the function with

    NameError: name 'tempfile' is not defined

Root cause: `tempfile` is used but not imported in the module.

Changes:
- Added `import tempfile` to the top imports cell in `nbs/03b_net.ipynb`
- Ran `nbdev-export` → clean diff in `fastcore/net.py`
- Verified with local repro: download now succeeds without error

Tested with `nbdev-test` (passed).