### PR TITLE
fix import-no-init

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -435,7 +435,7 @@ def import_no_init(name):
     from importlib.machinery import PathFinder
     import importlib.util as iu
     parts = name.split('.')
-    spec = PathFinder.find_spec(parts[0])
+    spec = PathFinder.find_spec(parts[0]) or iu.find_spec(parts[0])
     path = Path(spec.origin)
     if len(parts)>1: path = path.parent.joinpath(*parts[1:]).with_suffix('.py')
     spec = iu.spec_from_file_location(name, path)

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -1415,7 +1415,7 @@
     "    from importlib.machinery import PathFinder\n",
     "    import importlib.util as iu\n",
     "    parts = name.split('.')\n",
-    "    spec = PathFinder.find_spec(parts[0])\n",
+    "    spec = PathFinder.find_spec(parts[0]) or iu.find_spec(parts[0])\n",
     "    path = Path(spec.origin)\n",
     "    if len(parts)>1: path = path.parent.joinpath(*parts[1:]).with_suffix('.py')\n",
     "    spec = iu.spec_from_file_location(name, path)\n",


### PR DESCRIPTION
fixes #815 

When running the xtra notebook locally I'm getting the following error:

```txt
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[75], line 1
----> 1 m = import_no_init('fastcore.basics')
      2 test_eq(m.__name__, 'fastcore.basics')
      3 assert hasattr(m, 'store_attr')
      4 

Cell In[74], line 7, in import_no_init(name)
      3     from importlib.machinery import PathFinder
      4     import importlib.util as iu
      5     parts = name.split('.')
      6     spec = PathFinder.find_spec(parts[0])
----> 7     path = Path(spec.origin)
      8     if len(parts)>1: path = path.parent.joinpath(*parts[1:]).with_suffix('.py')
      9     spec = iu.spec_from_file_location(name, path)
     10     mod = iu.module_from_spec(spec)

AttributeError: 'NoneType' object has no attribute 'origin'
```

On my machine fastcore is an editable install and `PathFinder.find_spec` can't find it. 
`iu.find_spec` can find it. 

This pr makes the following change.

`spec = PathFinder.find_spec(parts[0])`

to 

`spec = PathFinder.find_spec(parts[0]) or iu.find_spec(parts[0])`.