### PR TITLE
Use `tmp` for atomic_save temp file suffix

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -422,7 +422,7 @@ def atomic_save(fn, mode='wb', uid=-1, gid=-1, **kwargs):
     from tempfile import NamedTemporaryFile as ntf
     fn = Path(fn)
     fn.parent.mkdir_perms(parents=True, exist_ok=True, uid=uid, gid=gid)
-    with ntf(mode=mode, dir=fn.parent, delete=False, suffix=fn.suffix, **kwargs) as f:
+    with ntf(mode=mode, dir=fn.parent, delete=False, suffix='tmp', **kwargs) as f:
         try: yield f
         except:
             Path(f.name).unlink(missing_ok=True)

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -1377,13 +1377,14 @@
     "    from tempfile import NamedTemporaryFile as ntf\n",
     "    fn = Path(fn)\n",
     "    fn.parent.mkdir_perms(parents=True, exist_ok=True, uid=uid, gid=gid)\n",
-    "    with ntf(mode=mode, dir=fn.parent, delete=False, suffix=fn.suffix, **kwargs) as f:\n",
+    "    with ntf(mode=mode, dir=fn.parent, delete=False, suffix='tmp', **kwargs) as f:\n",
     "        try: yield f\n",
     "        except:\n",
     "            Path(f.name).unlink(missing_ok=True)\n",
     "            raise\n",
     "    if uid>-1 or gid>-1: os.chown(f.name, uid, gid)\n",
-    "    Path(f.name).rename(fn)\n"
+    "    Path(f.name).rename(fn)\n",
+    ""
    ]
   },
   {
@@ -1732,7 +1733,8 @@
     "#| export\n",
     "def is_listy(x):\n",
     "    \"`isinstance(x, (tuple,list,L,slice,Generator,set,frozenset))`\"\n",
-    "    return isinstance(x, (tuple,list,L,slice,Generator,set,frozenset))\n"
+    "    return isinstance(x, (tuple,list,L,slice,Generator,set,frozenset))\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
This PR modifies the temporary file's suffix in `atomic_save` to use the `.tmp` suffix regardless of original file-type. Since certain file suffixes interact with programs (for example, `.ipynb` notebook files and `nbdev`), using a static extension designed for temporary files feels the safest. The original file suffix is set along with the name when we rename the tmp file, so I don't believe this should cause any issues?