### PR TITLE
uid and gid in untar_dir params

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -261,8 +261,8 @@ def _unpack(fname, out):
     return ls[0] if len(ls) == 1 else out
 
 # %% ../nbs/03_xtras.ipynb #6f1e90e9
-def untar_dir(fname, dest, rename=False, overwrite=False):
-    "untar `file` into `dest`, creating a directory if the root contains more than one item"
+def untar_dir(fname, dest, rename=False, overwrite=False, uid=-1, gid=-1):
+    "untar `file` into `dest`, creating a directory if the root contains more than one item; recursively chown if `uid`/`gid` set"
     import tempfile,shutil
     dest = Path(dest)
     with tempfile.TemporaryDirectory() as d:
@@ -277,6 +277,10 @@ def untar_dir(fname, dest, rename=False, overwrite=False):
             else: return dest
         if rename: src = _unpack(fname, out)
         shutil.move(str(src), dest)
+        if uid>-1 or gid>-1:
+            os.chown(dest, uid, gid)
+            if dest.is_dir():
+                for p in dest.rglob('*'): os.chown(p, uid, gid)
         return dest
 
 # %% ../nbs/03_xtras.ipynb #ab91ee87

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -845,8 +845,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def untar_dir(fname, dest, rename=False, overwrite=False):\n",
-    "    \"untar `file` into `dest`, creating a directory if the root contains more than one item\"\n",
+    "def untar_dir(fname, dest, rename=False, overwrite=False, uid=-1, gid=-1):\n",
+    "    \"untar `file` into `dest`, creating a directory if the root contains more than one item; recursively chown if `uid`/`gid` set\"\n",
     "    import tempfile,shutil\n",
     "    dest = Path(dest)\n",
     "    with tempfile.TemporaryDirectory() as d:\n",
@@ -861,6 +861,10 @@
     "            else: return dest\n",
     "        if rename: src = _unpack(fname, out)\n",
     "        shutil.move(str(src), dest)\n",
+    "        if uid>-1 or gid>-1:\n",
+    "            os.chown(dest, uid, gid)\n",
+    "            if dest.is_dir():\n",
+    "                for p in dest.rglob('*'): os.chown(p, uid, gid)\n",
     "        return dest"
    ]
   },
@@ -1383,8 +1387,7 @@
     "            Path(f.name).unlink(missing_ok=True)\n",
     "            raise\n",
     "    if uid>-1 or gid>-1: os.chown(f.name, uid, gid)\n",
-    "    Path(f.name).rename(fn)\n",
-    ""
+    "    Path(f.name).rename(fn)\n"
    ]
   },
   {
@@ -1733,8 +1736,7 @@
     "#| export\n",
     "def is_listy(x):\n",
     "    \"`isinstance(x, (tuple,list,L,slice,Generator,set,frozenset))`\"\n",
-    "    return isinstance(x, (tuple,list,L,slice,Generator,set,frozenset))\n",
-    ""
+    "    return isinstance(x, (tuple,list,L,slice,Generator,set,frozenset))\n"
    ]
   },
   {


### PR DESCRIPTION
This PR adds `uid` and `gid` options to `untar_dir()`, which when set permissions on extracted archive files