### PR TITLE
Use string_classes constant instead of hardcoded (str, bytes) tuples

### DIFF
--- a/fastcore/foundation.py
+++ b/fastcore/foundation.py
@@ -623,7 +623,7 @@ def flatten(self:L):
     "Recursively flatten nested iterables (except strings)"
     def _flatten(o):
         for item in o:
-            if isinstance(item, (str,bytes)) or not hasattr(item,'__iter__'): yield item
+            if isinstance(item, string_classes) or not hasattr(item,'__iter__'): yield item
             else: yield from _flatten(item)
     return self._new(_flatten(self))
 

--- a/fastcore/net.py
+++ b/fastcore/net.py
@@ -113,7 +113,7 @@ def urlopen(url, data=None, headers=None, timeout=None, **kwargs):
     "Like `urllib.request.urlopen`, but first `urlwrap` the `url`, and encode `data`"
     if kwargs and not data: data=kwargs
     if data is not None:
-        if not isinstance(data, (str,bytes)): data = urlencode(data)
+        if not isinstance(data, string_classes): data = urlencode(data)
         if not isinstance(data, bytes): data = data.encode('ascii')
     try: return urlopener().open(urlwrap(url, data=data, headers=headers), timeout=timeout)
     except HTTPError as e: 

--- a/nbs/02_foundation.ipynb
+++ b/nbs/02_foundation.ipynb
@@ -4040,7 +4040,7 @@
     "    \"Recursively flatten nested iterables (except strings)\"\n",
     "    def _flatten(o):\n",
     "        for item in o:\n",
-    "            if isinstance(item, (str,bytes)) or not hasattr(item,'__iter__'): yield item\n",
+    "            if isinstance(item, string_classes) or not hasattr(item,'__iter__'): yield item\n",
     "            else: yield from _flatten(item)\n",
     "    return self._new(_flatten(self))"
    ]

--- a/nbs/03b_net.ipynb
+++ b/nbs/03b_net.ipynb
@@ -347,7 +347,7 @@
     "    \"Like `urllib.request.urlopen`, but first `urlwrap` the `url`, and encode `data`\"\n",
     "    if kwargs and not data: data=kwargs\n",
     "    if data is not None:\n",
-    "        if not isinstance(data, (str,bytes)): data = urlencode(data)\n",
+    "        if not isinstance(data, string_classes): data = urlencode(data)\n",
     "        if not isinstance(data, bytes): data = data.encode('ascii')\n",
     "    try: return urlopener().open(urlwrap(url, data=data, headers=headers), timeout=timeout)\n",
     "    except HTTPError as e: \n",


### PR DESCRIPTION
fastcore/imports.py already defines string_classes = (str, bytes), but L.flatten and urlopen use the hardcoded tuple directly. This PR updates those occurrences to use the named constant.