### PR TITLE
Fix mk_cell overwriting caller-provided outputs and execution_count

### DIFF
--- a/fastcore/nbio.py
+++ b/fastcore/nbio.py
@@ -96,8 +96,8 @@ def mk_cell(
     assert cell_type in {'code', 'markdown', 'raw'}
     if 'metadata' not in kwargs: kwargs['metadata']={}
     if cell_type == 'code':
-        kwargs['outputs']=[]
-        kwargs['execution_count']=0
+        kwargs.setdefault('outputs', [])
+        kwargs.setdefault('execution_count', None)
     return NbCell(0, dict(cell_type=cell_type, source=text, directives_={}, **kwargs))
 
 # %% ../nbs/13_nbio.ipynb #e7af3290

--- a/nbs/13_nbio.ipynb
+++ b/nbs/13_nbio.ipynb
@@ -110,7 +110,7 @@
        "{'solveit_dialog_mode': 'learning', 'solveit_ver': 2}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -151,7 +151,7 @@
        "  'source': ['# Do some arithmetic\\n', '1+1']}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -328,7 +328,7 @@
        " 'idx_': 1}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -356,10 +356,10 @@
     {
      "data": {
       "text/plain": [
-       "([1 + 1], )"
+       "([<ast.Expr at 0x7f5644251e50>], <ast.Add at 0x7f566f08ea10>)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -403,7 +403,7 @@
        "\"{'cell_type': 'markdown', 'id': '801558df', 'metadata': {}, 'source': '## A minimal notebook', 'idx_': 0}\""
       ]
      },
-     "execution_count": null,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -433,7 +433,7 @@
        "'../tests/minimal.ipynb'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -467,8 +467,8 @@
     "    assert cell_type in {'code', 'markdown', 'raw'}\n",
     "    if 'metadata' not in kwargs: kwargs['metadata']={}\n",
     "    if cell_type == 'code':\n",
-    "        kwargs['outputs']=[]\n",
-    "        kwargs['execution_count']=0\n",
+    "        kwargs.setdefault('outputs', [])\n",
+    "        kwargs.setdefault('execution_count', None)\n",
     "    return NbCell(0, dict(cell_type=cell_type, source=text, directives_={}, **kwargs))"
    ]
   },
@@ -487,7 +487,7 @@
        "{ 'cell_type': 'code',\n",
        "  'directives_': {},\n",
        "  'execution_count': 0,\n",
-       "  'id': '76f21c66',\n",
+       "  'id': 'f5895235',\n",
        "  'idx_': 0,\n",
        "  'metadata': {},\n",
        "  'outputs': [],\n",
@@ -504,10 +504,10 @@
        " 'metadata': {},\n",
        " 'outputs': [],\n",
        " 'idx_': 0,\n",
-       " 'id': '76f21c66'}"
+       " 'id': 'f5895235'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -700,7 +700,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[{'cell_type': 'code', 'execution_count': 0, 'id': '0494fb5d', 'metadata': {}, 'outputs': [], 'source': 'print(1)', 'idx_': 0}]\n"
+      "[{'cell_type': 'code', 'execution_count': None, 'id': '0575a9e0', 'metadata': {}, 'outputs': [], 'source': 'print(1)', 'idx_': 0}]\n"
      ]
     }
    ],
@@ -810,7 +810,7 @@
        "(('text/html', ['<b>42</b>']), ('text/html', ['<b>42</b>']))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -925,7 +925,7 @@
        " {'output_type': 'stream', 'name': 'stderr', 'text': 'warn\\n'}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -952,7 +952,7 @@
        "  'metadata': {}}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1240,7 +1240,7 @@
        "'<code id=\"c0\">a=1\\na</code>'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1261,7 +1261,7 @@
        "'<code id=\"c0\"><source>a=1\\na<out>1\\n</out></code>'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1330,7 +1330,7 @@
        "(['solveit_dialog_mode', 'solveit_ver'], 2, 2)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1352,7 +1352,7 @@
        "'minimal.ipynb'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 97,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1373,7 +1373,7 @@
        "['801558df', 'e2147a69']"
       ]
      },
-     "execution_count": null,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1394,7 +1394,7 @@
        "(True, False)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1420,11 +1420,11 @@
     {
      "data": {
       "text/plain": [
-       "<nb path=\"/Users/jhoward/aai-ws/fastcore/tests/minimal.ipynb\"><markdown id=\"801558df\">## A minimal notebook</markdown><code id=\"e2147a69\"><source># Do some arithmetic\n",
+       "<nb path=\"/home/natedawg/aai-ws/fastcore/tests/minimal.ipynb\"><markdown id=\"801558df\">## A minimal notebook</markdown><code id=\"e2147a69\"><source># Do some arithmetic\n",
        "1+1<out>2</out></code></nb>"
       ]
      },
-     "execution_count": null,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1480,7 +1480,7 @@
        "'## A minimal notebook'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1501,7 +1501,7 @@
        "'# Do some arithmetic\\n1+1'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1530,7 +1530,7 @@
        "'2+2'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1560,7 +1560,7 @@
        "[{'output_type': 'execute_result', 'data': {'text/plain': ['4']}}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1591,7 +1591,7 @@
        "{'time_run': '2026-01-04T20:52:49.901559+00:00', 'custom': True}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1643,7 +1643,7 @@
        "(4, '## A minimal notebook')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1674,7 +1674,7 @@
        "['# Before first', '## A minimal notebook', '# After first']"
       ]
      },
-     "execution_count": null,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1720,7 +1720,7 @@
        "(7, 'markdown')"
       ]
      },
-     "execution_count": null,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1750,7 +1750,7 @@
        "True"
       ]
      },
-     "execution_count": null,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1802,7 +1802,7 @@
        "  'idx_': 1}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1851,7 +1851,7 @@
        "True"
       ]
      },
-     "execution_count": null,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1938,7 +1938,15 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "solveit": {
+   "default_code": false,
+   "mode": "learning",
+   "use_thinking": false,
+   "use_tools": false,
+   "ver": 2
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

`mk_cell` was unconditionally clobbering `outputs` and `execution_count` for code cells, even when the caller explicitly passed values for them. It also defaulted
`execution_count` to `0` instead of `None` (the Jupyter convention for unexecuted cells).

## Changes

- Use `kwargs.setdefault('outputs', [])` and `kwargs.setdefault('execution_count', None)` so caller-supplied values are respected.
- Default `execution_count` is now `None` instead of `0`, matching standard Jupyter notebook and nbdev-clean behavior.