### PR TITLE
`render_text` gains `include_imgs=`, rendering image outputs as mime-tagged elements

### DIFF
--- a/fastcore/nbio.py
+++ b/fastcore/nbio.py
@@ -472,24 +472,27 @@ def render_outputs(outputs):
     if (not isinstance(outputs, (list,tuple))) or (outputs and not isinstance(outputs[0],dict)): return ''
     return '\n'.join(render_output(o) for o in concat_streams(outputs))
 
-# %% ../nbs/13_nbio.ipynb #88b0018a
-def _render_text(out, html1st=False):
+# %% ../nbs/13_nbio.ipynb #94121eb2
+def _render_text(out, html1st=False, include_imgs=False):
     typ = out['output_type']
-    mime,d = preferred_msg_out(out, html1st=html1st, include_imgs=False)
+    mime,d = preferred_msg_out(out, html1st=html1st, include_imgs=include_imgs)
     d = _join(d)
     if not d: return None
     attrs = {}
     if typ == 'stream': typ = out.get('name')
     elif typ in ('execute_result','display_data') and mime!='text/plain': attrs['mime'] = mime
     body = f'\n{d}' if d.endswith('\n') else f'\n{d}\n'
-    return d, to_xml(ft(typ, body, **attrs), do_escape=False, indent=False)
+    return d,to_xml(ft(typ, body, **attrs), do_escape=False, indent=False),mime
 
-def render_text(outputs, html1st=False):
-    "Render notebook outputs to concise text, using XML-ish tags when multiple outputs are present."
+def render_text(outputs, html1st=False, include_imgs=False):
+    "Render notebook outputs to concise text, retaining XML tags when needed to preserve structure."
     if (not isinstance(outputs, (list,tuple))) or (outputs and not isinstance(outputs[0],dict)): return ''
-    items = [o for out in concat_streams(outputs) if (o := _render_text(out, html1st=html1st))]
+    items = [o for out in concat_streams(outputs)
+             if (o := _render_text(out, html1st=html1st, include_imgs=include_imgs))]
     if not items: return ''
-    return items[0][0] if len(items)==1 else '\n'.join(o[1] for o in items)
+    if len(items)>1: return '\n'.join(o[1] for o in items)
+    d,xml,mime = items[0]
+    return xml if mime.startswith('image/') else d
 
 # %% ../nbs/13_nbio.ipynb #d32fc4bc
 def item2xml(

--- a/nbs/13_nbio.ipynb
+++ b/nbs/13_nbio.ipynb
@@ -113,7 +113,7 @@
        "{'solveit_dialog_mode': 'learning', 'solveit_ver': 2}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -154,7 +154,7 @@
        "  'source': ['# Do some arithmetic\\n', '1+1']}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -370,7 +370,7 @@
        " 'lang_': 'python'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -398,10 +398,10 @@
     {
      "data": {
       "text/plain": [
-       "([1 + 1], )"
+       "([<ast.Expr at 0x7f04d07aa090>], <ast.Add at 0x7f05058dc190>)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -445,7 +445,7 @@
        "\"{'cell_type': 'markdown', 'id': '801558df', 'metadata': {}, 'source': '## A minimal notebook', 'idx_': 0, 'lang_': 'python'}\""
       ]
      },
-     "execution_count": null,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -475,7 +475,7 @@
        "'../tests/minimal.ipynb'"
       ]
      },
-     "execution_count": null,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -529,7 +529,7 @@
        "{ 'cell_type': 'code',\n",
        "  'directives_': {},\n",
        "  'execution_count': 0,\n",
-       "  'id': '37dd5d5e',\n",
+       "  'id': '91d889f5',\n",
        "  'idx_': 0,\n",
        "  'lang_': 'python',\n",
        "  'metadata': {},\n",
@@ -548,10 +548,10 @@
        " 'outputs': [],\n",
        " 'idx_': 0,\n",
        " 'lang_': 'python',\n",
-       " 'id': '37dd5d5e'}"
+       " 'id': '91d889f5'}"
       ]
      },
-     "execution_count": null,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1228,7 +1228,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[{'cell_type': 'code', 'execution_count': None, 'id': 'b00e7cbc', 'metadata': {}, 'outputs': [], 'source': 'print(1)', 'idx_': 0, 'lang_': 'python'}]\n"
+      "[{'cell_type': 'code', 'execution_count': None, 'id': 'e32c63b3', 'metadata': {}, 'outputs': [], 'source': 'print(1)', 'idx_': 0, 'lang_': 'python'}]\n"
      ]
     }
    ],
@@ -1493,7 +1493,7 @@
        "(('text/html', ['<b>42</b>']), ('text/html', ['<b>42</b>']))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1590,7 +1590,7 @@
        " {'output_type': 'stream', 'name': 'stderr', 'text': 'warn\\n'}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1617,7 +1617,7 @@
        "  'metadata': {}}]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1767,28 +1767,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88b0018a",
+   "id": "94121eb2",
    "metadata": {},
    "outputs": [],
    "source": [
     "#| export\n",
-    "def _render_text(out, html1st=False):\n",
+    "def _render_text(out, html1st=False, include_imgs=False):\n",
     "    typ = out['output_type']\n",
-    "    mime,d = preferred_msg_out(out, html1st=html1st, include_imgs=False)\n",
+    "    mime,d = preferred_msg_out(out, html1st=html1st, include_imgs=include_imgs)\n",
     "    d = _join(d)\n",
     "    if not d: return None\n",
     "    attrs = {}\n",
     "    if typ == 'stream': typ = out.get('name')\n",
     "    elif typ in ('execute_result','display_data') and mime!='text/plain': attrs['mime'] = mime\n",
     "    body = f'\\n{d}' if d.endswith('\\n') else f'\\n{d}\\n'\n",
-    "    return d, to_xml(ft(typ, body, **attrs), do_escape=False, indent=False)\n",
+    "    return d,to_xml(ft(typ, body, **attrs), do_escape=False, indent=False),mime\n",
     "\n",
-    "def render_text(outputs, html1st=False):\n",
-    "    \"Render notebook outputs to concise text, using XML-ish tags when multiple outputs are present.\"\n",
+    "def render_text(outputs, html1st=False, include_imgs=False):\n",
+    "    \"Render notebook outputs to concise text, retaining XML tags when needed to preserve structure.\"\n",
     "    if (not isinstance(outputs, (list,tuple))) or (outputs and not isinstance(outputs[0],dict)): return ''\n",
-    "    items = [o for out in concat_streams(outputs) if (o := _render_text(out, html1st=html1st))]\n",
+    "    items = [o for out in concat_streams(outputs)\n",
+    "             if (o := _render_text(out, html1st=html1st, include_imgs=include_imgs))]\n",
     "    if not items: return ''\n",
-    "    return items[0][0] if len(items)==1 else '\\n'.join(o[1] for o in items)"
+    "    if len(items)>1: return '\\n'.join(o[1] for o in items)\n",
+    "    d,xml,mime = items[0]\n",
+    "    return xml if mime.startswith('image/') else d"
    ]
   },
   {
@@ -1862,7 +1865,11 @@
     "test_eq(render_text(disp), '**42**')\n",
     "test_eq(render_text(disp, html1st=True), '<b>42</b>')\n",
     "\n",
+    "img = [mk_display(image_png='abc')]\n",
     "test_eq(render_text([mk_display(image_png='abc')]), '')\n",
+    "test_eq(render_text(img), '')\n",
+    "test_eq(render_text(img, include_imgs=True),\n",
+    "        '<display_data mime=\"image/png\">\\nabc\\n</display_data>')\n",
     "test_eq(render_text([mk_error('oops')]), 'oops')"
    ]
   },
@@ -2846,10 +2853,11 @@
  ],
  "metadata": {
   "solveit": {
+   "autosave": false,
    "default_code": false,
    "mode": "learning",
-   "use_thinking": false,
-   "use_tools": false,
+   "use_thinking": true,
+   "use_tools": true,
    "ver": 2
   }
  },


### PR DESCRIPTION
`render_text` now takes `include_imgs`, passed through to `preferred_msg_out`, so image outputs render as elements carrying their mime type, e.g. `<display_data mime="image/png">...</display_data>` with the base64 data as the body.