### PR TITLE
Fix asdict UnboundLocalError for iterables of non-pairs

### DIFF
--- a/fastcore/xtras.py
+++ b/fastcore/xtras.py
@@ -1091,13 +1091,13 @@ def flexiclass(
 def asdict(o)->dict:
     "Convert `o` to a `dict`, supporting dataclasses, namedtuples, iterables, and `__dict__` attrs."
     if isinstance(o, dict): return o
+    r = None
     if hasattr(o, '_asdict'): r = o._asdict()
     elif is_dataclass(o): r = dataclasses.asdict(o)
     elif hasattr(o, '__iter__'):
         try: r = dict(o)
         except TypeError: pass
-    elif hasattr(o, '__flds__'): r = {x:getattr(o,x) for x in o.__flds__}
-    else: r = vars(o)
+    if r is None: r = {x:getattr(o,x) for x in o.__flds__} if hasattr(o, '__flds__') else vars(o)
     skip = set(getattr(o, '__skip__', []))
     return {k:v for k,v in r.items() if v is not UNSET and v is not MISSING and k not in skip}
 

--- a/nbs/03_xtras.ipynb
+++ b/nbs/03_xtras.ipynb
@@ -5189,13 +5189,13 @@
     "def asdict(o)->dict:\n",
     "    \"Convert `o` to a `dict`, supporting dataclasses, namedtuples, iterables, and `__dict__` attrs.\"\n",
     "    if isinstance(o, dict): return o\n",
+    "    r = None\n",
     "    if hasattr(o, '_asdict'): r = o._asdict()\n",
     "    elif is_dataclass(o): r = dataclasses.asdict(o)\n",
     "    elif hasattr(o, '__iter__'):\n",
     "        try: r = dict(o)\n",
     "        except TypeError: pass\n",
-    "    elif hasattr(o, '__flds__'): r = {x:getattr(o,x) for x in o.__flds__}\n",
-    "    else: r = vars(o)\n",
+    "    if r is None: r = {x:getattr(o,x) for x in o.__flds__} if hasattr(o, '__flds__') else vars(o)\n",
     "    skip = set(getattr(o, '__skip__', []))\n",
     "    return {k:v for k,v in r.items() if v is not UNSET and v is not MISSING and k not in skip}"
    ]
@@ -5251,6 +5251,28 @@
     "\n",
     "obj = CustomObj()\n",
     "test_eq(asdict(obj), {'a': 1, 'c': 3, 'd': 4})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "572d4c44",
+   "metadata": {},
+   "source": [
+    "An object may be iterable without yielding key-value pairs; since `dict` can't consume it, `asdict` falls back to its instance attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03cfa854",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class IterObj:\n",
+    "    def __init__(self): self.a,self.b = 1,2\n",
+    "    def __iter__(self): return iter([self.a,self.b])\n",
+    "\n",
+    "test_eq(asdict(IterObj()), dict(a=1,b=2))"
    ]
   },
   {


### PR DESCRIPTION
`asdict` crashed with `UnboundLocalError: cannot access local variable 'r'` for any object whose `__iter__` yields elements that aren't key-value pairs: the `dict(o)` conversion raises `TypeError`, the `except TypeError: pass` swallows it, and `r` is left unbound when the final `r.items()` runs.

This was latent until AnswerDotAI/llmsurgery@e388b8b added `__iter__` to `Dialog` (iterating over its messages), which flipped `Dialog` from the `vars(o)` branch into the `__iter__` branch and triggered the crash in `Dialog.todict()`.

The fix uses an `r = None` sentinel so a failed `dict(o)` conversion falls back to the existing `__flds__`/`vars(o)` path, restoring the previous behavior for such objects. Branch order is unchanged for everything that worked before. Includes a test (written red-green) for an iterable-of-non-pairs object falling back to instance attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)