### PR TITLE
Add WebP and GIF image support

### DIFF
--- a/fastcore/nbio.py
+++ b/fastcore/nbio.py
@@ -439,7 +439,7 @@ from .ansi import strip_ansi
 def preferred_out(data, html1st=True, include_imgs=False):
     preftyps = ('application/javascript', 'text/latex')
     preftyps = (('text/html', 'text/markdown') if html1st else ('text/markdown', 'text/html')) + preftyps
-    if include_imgs: preftyps += 'image/jpeg','image/png','image/svg+xml'
+    if include_imgs: preftyps += 'image/jpeg','image/png','image/webp','image/gif','image/svg+xml'
     preftyps += ('text/plain',)
     for mt in preftyps:
         if (text := data.get(mt)): return mt,text
@@ -547,7 +547,7 @@ def _render_md(out, html1st=True):
     elif mime=='application/javascript': return 'md', fenced(f'<script>{d}</script>', '{=html}')
     elif mime=='image/svg+xml': return 'md', fenced(d.strip(), '{=html}')
     elif mime in ('text/markdown','text/latex'): return 'md', d.strip()
-    elif mime in ('image/jpeg','image/png'): return 'md', f'![](data:{mime};base64,{"".join(d.split())})'
+    elif mime in ('image/jpeg','image/png','image/webp','image/gif'): return 'md', f'![](data:{mime};base64,{"".join(d.split())})'
     return None
 
 def render_md(outputs, html1st=True):

--- a/nbs/13_nbio.ipynb
+++ b/nbs/13_nbio.ipynb
@@ -1583,7 +1583,7 @@
     "def preferred_out(data, html1st=True, include_imgs=False):\n",
     "    preftyps = ('application/javascript', 'text/latex')\n",
     "    preftyps = (('text/html', 'text/markdown') if html1st else ('text/markdown', 'text/html')) + preftyps\n",
-    "    if include_imgs: preftyps += 'image/jpeg','image/png','image/svg+xml'\n",
+    "    if include_imgs: preftyps += 'image/jpeg','image/png','image/webp','image/gif','image/svg+xml'\n",
     "    preftyps += ('text/plain',)\n",
     "    for mt in preftyps:\n",
     "        if (text := data.get(mt)): return mt,text\n",
@@ -2033,7 +2033,7 @@
     "    elif mime=='application/javascript': return 'md', fenced(f'<script>{d}</script>', '{=html}')\n",
     "    elif mime=='image/svg+xml': return 'md', fenced(d.strip(), '{=html}')\n",
     "    elif mime in ('text/markdown','text/latex'): return 'md', d.strip()\n",
-    "    elif mime in ('image/jpeg','image/png'): return 'md', f'![](data:{mime};base64,{\"\".join(d.split())})'\n",
+    "    elif mime in ('image/jpeg','image/png','image/webp','image/gif'): return 'md', f'![](data:{mime};base64,{\"\".join(d.split())})'\n",
     "    return None\n",
     "\n",
     "def render_md(outputs, html1st=True):\n",
@@ -2087,6 +2087,8 @@
     "test_eq(render_md(disp, html1st=False), '**42**')\n",
     "\n",
     "test_eq(render_md([mk_display(image_png='abc')]), '![](data:image/png;base64,abc)')\n",
+    "test_eq(render_md([mk_display(image_webp='abc')]), '![](data:image/webp;base64,abc)')\n",
+    "test_eq(render_md([mk_display(image_gif='abc')]), '![](data:image/gif;base64,abc)')\n",
     "test_eq(render_md([mk_error('oops')]), fenced('oops', 'output'))\n",
     "test_eq(render_md([mk_stream('stdout', 'a `` b\\n')]), '```output\\na `` b\\n```')"
    ]


### PR DESCRIPTION
Extends preferred_out and render_md in 
nbio.py to handle image/webp and image/gif MIME types. Adds corresponding tests.