### PR TITLE
note that path param expands ~ in file/cell editing functions

### DIFF
--- a/fastcore/nbio.py
+++ b/fastcore/nbio.py
@@ -289,7 +289,7 @@ def find_id(
 _cell_edit_doc = """
 This is a *cell* editing function.
 
-Cell editing standard parameters are `path`: notebook file to modify, and `cell_id`: id of the cell to edit (exact, or unique prefix)
+Cell editing standard parameters are `path`: notebook file to modify (expands `~`), and `cell_id`: id of the cell to edit (exact, or unique prefix)
 
 returns: diff of changes, or "none: No changes.", or "error: ..."
 """
@@ -327,7 +327,7 @@ __pyskill_params__ = {'replace_params': ('start_line', 'end_line', 'n_matches', 
 
 # %% ../nbs/13_nbio.ipynb #421b2b9c
 def view_cell(
-    path:str, # Notebook file to read
+    path:str, # Notebook file to read (expands `~`)
     cell_id:str, # Id of the cell to view (exact, or unique prefix)
     start_line:int=1, # Starting line to view
     end_line:int=None, # End line (defaults to last line if None; may be past EOF, which clamps to the last line)

--- a/fastcore/tools.py
+++ b/fastcore/tools.py
@@ -202,7 +202,7 @@ def create_file(
 _file_edit_doc = """
 This is a *file* editing function.
 
-File editing standard parameter is `path`: Path to the file to modify
+File editing standard parameter is `path`: Path to the file to modify (expands `~`)
 
 returns: diff of changes, or "none: No changes.", or "error: ..."
 """

--- a/nbs/12_tools.ipynb
+++ b/nbs/12_tools.ipynb
@@ -606,7 +606,7 @@
     "_file_edit_doc = \"\"\"\n",
     "This is a *file* editing function.\n",
     "\n",
-    "File editing standard parameter is `path`: Path to the file to modify\n",
+    "File editing standard parameter is `path`: Path to the file to modify (expands `~`)\n",
     "\n",
     "returns: diff of changes, or \"none: No changes.\", or \"error: ...\"\n",
     "\"\"\""

--- a/nbs/13_nbio.ipynb
+++ b/nbs/13_nbio.ipynb
@@ -1186,7 +1186,7 @@
     "_cell_edit_doc = \"\"\"\n",
     "This is a *cell* editing function.\n",
     "\n",
-    "Cell editing standard parameters are `path`: notebook file to modify, and `cell_id`: id of the cell to edit (exact, or unique prefix)\n",
+    "Cell editing standard parameters are `path`: notebook file to modify (expands `~`), and `cell_id`: id of the cell to edit (exact, or unique prefix)\n",
     "\n",
     "returns: diff of changes, or \"none: No changes.\", or \"error: ...\"\n",
     "\"\"\"\n",
@@ -1256,7 +1256,7 @@
    "source": [
     "#| export\n",
     "def view_cell(\n",
-    "    path:str, # Notebook file to read\n",
+    "    path:str, # Notebook file to read (expands `~`)\n",
     "    cell_id:str, # Id of the cell to view (exact, or unique prefix)\n",
     "    start_line:int=1, # Starting line to view\n",
     "    end_line:int=None, # End line (defaults to last line if None; may be past EOF, which clamps to the last line)\n",


### PR DESCRIPTION
Updated docstrings across  and  to clarify that the  parameter expands the  home directory prefix. Affects:

- `find_id` cell edit doc
- `view_cell` parameter doc
- `create_file` file edit doc

This improves discoverability of the tilde-expansion behavior for users of these helper functions.