### PR TITLE
Fix kwargs docments with full output

### DIFF
--- a/fastcore/docments.py
+++ b/fastcore/docments.py
@@ -187,7 +187,7 @@ def docments(s, full=False, eval_str=False, returns=True, args_kwargs=False):
     nps = parse_docstring(s)
     docs = {}
     while s:
-        p = _param_locs(s, returns=returns, args_kwargs=args_kwargs) or {}
+        p = _param_locs(s, returns=returns, args_kwargs=args_kwargs or full) or {}
         c = {o.start[0]:_clean_comment(o.string) for o in _tokens(s) if o.type==COMMENT}
         for k,v in p.items():
             if v not in docs: docs[v] = _get_comment(k, v, c, p)

--- a/nbs/04_docments.ipynb
+++ b/nbs/04_docments.ipynb
@@ -724,7 +724,7 @@
     "    nps = parse_docstring(s)\n",
     "    docs = {}\n",
     "    while s:\n",
-    "        p = _param_locs(s, returns=returns, args_kwargs=args_kwargs) or {}\n",
+    "        p = _param_locs(s, returns=returns, args_kwargs=args_kwargs or full) or {}\n",
     "        c = {o.start[0]:_clean_comment(o.string) for o in _tokens(s) if o.type==COMMENT}\n",
     "        for k,v in p.items():\n",
     "            if v not in docs: docs[v] = _get_comment(k, v, c, p)\n",
@@ -1086,7 +1086,9 @@
     }
    ],
    "source": [
-    "docments(add, full=True)"
+    "_dm_full = docments(add, full=True)\n",
+    "test_eq(_dm_full.kwargs.docment, 'Passed to the `example` function')\n",
+    "_dm_full"
    ]
   },
   {


### PR DESCRIPTION
Fixes #909.

`docments(..., full=True)` now includes `**kwargs` docments, matching the documented behavior that full results include variadic parameter documentation.

A regression test was added to the existing `full=True` example.

## Tests

```sh
nbdev-test --path nbs/04_docments.ipynb
