### PR TITLE
Preserve generic parameters in docment renderers

### DIFF
--- a/fastcore/docments.py
+++ b/fastcore/docments.py
@@ -271,6 +271,7 @@ def _escape_markdown(s):
 # %% ../nbs/04_docments.ipynb #ced78f56
 def _maybe_nm(o):
     if (o == inspect._empty): return ''
+    if typing.get_origin(o) is not None: return inspect.formatannotation(o).replace(' ','')
     else: return o.__name__ if hasattr(o, '__name__') else str(o)
 
 # %% ../nbs/04_docments.ipynb #fe6d83f1

--- a/nbs/04_docments.ipynb
+++ b/nbs/04_docments.ipynb
@@ -1899,6 +1899,7 @@
     "#| export\n",
     "def _maybe_nm(o):\n",
     "    if (o == inspect._empty): return ''\n",
+    "    if typing.get_origin(o) is not None: return inspect.formatannotation(o).replace(' ','')\n",
     "    else: return o.__name__ if hasattr(o, '__name__') else str(o)"
    ]
   },
@@ -1911,7 +1912,8 @@
    "source": [
     "#| hide\n",
     "test_eq(_maybe_nm(list), 'list')\n",
-    "test_eq(_maybe_nm('fastai'), 'fastai')"
+    "test_eq(_maybe_nm('fastai'), 'fastai')\n",
+    "test_eq(_maybe_nm(tuple[str,int]), 'tuple[str,int]')"
    ]
   },
   {
@@ -2613,7 +2615,9 @@
     "def _va(a:int, *ids:str, **kw): pass\n",
     "test_eq(str(sig2str(_va)), 'def _va(\\n    a:int, *ids:str, **kw\\n):')\n",
     "def _vb(a, *args, **kwargs): pass\n",
-    "test_eq(str(sig2str(_vb)), 'def _vb(\\n    a, *args, **kwargs\\n):')"
+    "test_eq(str(sig2str(_vb)), 'def _vb(\\n    a, *args, **kwargs\\n):')\n",
+    "def _vg(items:list[str])->tuple[str,int]: pass\n",
+    "test_eq(str(sig2str(_vg)), 'def _vg(\\n    items:list[str]\\n)->tuple[str,int]:')"
    ]
   },
   {


### PR DESCRIPTION
Fixes #910.

Parameterized annotations now retain their type arguments when rendered by the docment renderers. For example:

- `list[str]` no longer renders as `list`
- `tuple[str, int]` no longer renders as `tuple`

The change updates the shared `_maybe_nm` helper, so it applies consistently to `DocmentText`, `DocmentList`, and `DocmentTbl`.

Tests cover both the shared formatter and an end-to-end `sig2str` result.