### PR TITLE
Fix `all_equal` treating trailing `None` as equal (#519)

### DIFF
--- a/fastcore/imports.py
+++ b/fastcore/imports.py
@@ -30,7 +30,9 @@ def is_coll(o):
 def all_equal(a,b):
     "Compares whether `a` and `b` are the same length and have the same contents"
     if not is_iter(b): return a==b
-    return all(equals(a_,b_) for a_,b_ in itertools.zip_longest(a,b))
+    missing = object()  # sentinel so a padded (missing) position never matches a real value, incl. `None`
+    return all(a_ is not missing and b_ is not missing and equals(a_,b_)
+               for a_,b_ in itertools.zip_longest(a,b,fillvalue=missing))
 
 def noop (x=None, *args, **kwargs):
     "Do nothing"

--- a/nbs/00_test.ipynb
+++ b/nbs/00_test.ipynb
@@ -293,7 +293,10 @@
    "outputs": [],
    "source": [
     "test(['abc'], ['abc'], all_equal)\n",
-    "test_fail(lambda: test(['abc'],['cab'], all_equal))"
+    "test_fail(lambda: test(['abc'],['cab'], all_equal))\n",
+    "# #519: a trailing  must not make unequal-length sequences compare equal\n",
+    "test_ne((13,), (13,None)); test_ne([13,14], [13,14,None]); test_ne((13,None), (13,))\n",
+    "test_eq([1,None], [1,None])  # aligned real Nones still compare equal"
    ]
   },
   {


### PR DESCRIPTION
## What

Fixes #519. `all_equal` reports two sequences as equal when they differ only by a **trailing `None`**, even though the docstring promises it compares "the same length and … the same contents".

## Why

```python
def all_equal(a,b):
    "Compares whether \`a\` and \`b\` are the same length and have the same contents"
    if not is_iter(b): return a==b
    return all(equals(a_,b_) for a_,b_ in itertools.zip_longest(a,b))
```

`itertools.zip_longest` pads the shorter sequence with its default `fillvalue=None`. Because real data can *contain* `None`, that padding is indistinguishable from a genuine trailing `None`: when the longer sequence's extra element is `None`, the padded pair `(None, None)` compares equal and the whole call returns `True`. Length is never actually checked.

Because `all_equal` backs `equals` → `test_eq`, this silently weakens assertions across the fastai ecosystem — `test_eq` passes when it should fail:

```python
from fastcore.test import test_eq
test_eq((13,), (13, None))       # should raise AssertionError — but passes
test_eq([13,14], [13,14,None])   # should raise — passes
```

(Note `test_eq((13,), (13, 14))` *does* correctly raise — the bug shows up **only** when the extra element is `None`, which is why it went unnoticed.)

## How

Use a unique `object()` sentinel as the `fillvalue` so a padded (missing) position can never equal a real value, including `None`:

```python
def all_equal(a,b):
    "Compares whether \`a\` and \`b\` are the same length and have the same contents"
    if not is_iter(b): return a==b
    missing = object()  # sentinel so a padded (missing) position never matches a real value, incl. None
    return all(a_ is not missing and b_ is not missing and equals(a_,b_)
               for a_,b_ in itertools.zip_longest(a,b,fillvalue=missing))
```

Behaviour is **byte-for-byte identical** for equal-length inputs; unequal-length inputs whose extra elements are non-`None` were already `False`. The only behaviour that changes is the buggy trailing-`None` case, which now correctly compares unequal.

## Tests

Per CONTRIBUTING ("a test that fails without your patch, and passes with it"), added to `nbs/00_test.ipynb` beside the existing `all_equal` tests:

```python
test_ne((13,), (13,None)); test_ne([13,14], [13,14,None]); test_ne((13,None), (13,))
test_eq([1,None], [1,None])  # aligned real Nones still compare equal
```

These fail on `main` (the `test_ne`s raise because the values compare equal) and pass with the fix. Aligned real-`None` sequences and all equal-length cases are unaffected.

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*