### PR TITLE
Fix in_jupyter() detection for IPython shell subclasses

### DIFF
--- a/fastcore/imports.py
+++ b/fastcore/imports.py
@@ -86,7 +86,7 @@ def in_colab():
 def in_jupyter():
     "Check if the code is running in a jupyter notebook"
     if not in_ipython(): return False
-    return 'InteractiveShell' in ipython_shell().__class__.__name__
+    return any('InteractiveShell' in c.__name__ for c in type(ipython_shell()).__mro__)
 
 def in_notebook():
     "Check if the code is running in a jupyter notebook"


### PR DESCRIPTION
## Summary

`in_jupyter()` previously checked only the *direct* class name of the IPython shell for the string `InteractiveShell`. Environments that subclass `ZMQInteractiveShell` (e.g. CaptureShell, Google Colab, and other custom kernels) use class names that do not contain `InteractiveShell`, so `in_jupyter()` incorrectly returned `False`.

## Change

Walk the MRO of the shell and return `True` if *any* ancestor class name contains `InteractiveShell`:

```py
   return any("InteractiveShell" in c.__name__ for c in type(ipython_shell()).__mro__)
```