### PR TITLE
Update CLI flags for fastcore.script hyphenation

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -1,7 +1,7 @@
 project:
   type: website
   pre-render: 
-    - pysym2md --output_file apilist.txt fastcore
+    - pysym2md --output-file apilist.txt fastcore
   resources: 
     - "*.txt"
   preview:


### PR DESCRIPTION
Update affected documentation, automation, tests, and saved notebook output to use the hyphenated CLI flags now generated from underscored `fastcore.script` parameters.

This keeps examples and build/test commands compatible with current fastcore.